### PR TITLE
First draft of scope checking

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@ let
 
   inherit (nixpkgs) pkgs;
 
-  f = import ./pyfactor.nix;
+  f = import ./hpython.nix;
 
 
   haskellPackages = if compiler == "default"

--- a/example/Example.hs
+++ b/example/Example.hs
@@ -20,11 +20,6 @@ import Language.Python.Internal.Optics
 import Language.Python.Internal.Syntax
 import Language.Python.Syntax
 
-{-
-def append_to(element, to=[]):
-    to.append(element)
-    return to
--}
 append_to a =
   Fundef a
     [Space]
@@ -238,3 +233,10 @@ optimize_tr st = do
               ]
       | otherwise = [r]
     looped name params s = [s]
+
+badly_scoped =
+  def_ "test" [p_ "a", p_ "b"]
+  [ var_ "c" .= 0
+  , if_ true_ [ var_ "c" .= 2]
+  , return_ $ var_ "a" .+ var_ "b" .+ var_ "c"
+  ]

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -9,23 +9,39 @@ import Language.Python.Validate.Syntax
 import Language.Python.Validate.Syntax.Error
 import Language.Python.Validate.Indentation
 import Language.Python.Validate.Indentation.Error
+import Language.Python.Validate.Scope
+import Language.Python.Validate.Scope.Error
 import Language.Python.Internal.Render
 
-runExample x =
+runExampleSyntax x =
   case validateStatementIndentation x of
     Failure errs -> print (errs :: [IndentationError '[] ()])
     Success a ->
-      case validateStatementSyntax (SyntaxContext {_inLoop = False, _inFunction = False}) a of
+      case validateStatementSyntax initialSyntaxContext a of
         Failure errs -> print (errs :: [SyntaxError '[Indentation] ()])
         Success a' -> putStrLn . renderLines $ renderStatement a'
 
+runExampleScope x =
+  case validateStatementIndentation x of
+    Failure errs -> print (errs :: [IndentationError '[] ()])
+    Success a ->
+      case validateStatementSyntax initialSyntaxContext a of
+        Failure errs -> print (errs :: [SyntaxError '[Indentation] ()])
+        Success a' ->
+          case runValidateScope initialScopeContext (validateStatementScope a') of
+            Failure errs -> print (errs :: [ScopeError '[Syntax, Indentation] ()])
+            Success a'' ->
+              putStrLn . renderLines $ renderStatement a''
+
 main = do
-  runExample (append_to ())
-  runExample (rewrite fixMDA append_to')
-  runExample (append_to'' ())
-  runExample bracketing
-  runExample (indentSpaces 2 append_to')
-  runExample (indentTabs append_to')
-  runExample (rewrite optimize_tr fact_tr)
-  runExample (rewrite optimize_tr spin)
-  runExample (rewrite optimize_tr yes)
+  runExampleSyntax (append_to ())
+  runExampleSyntax (rewrite fixMDA append_to')
+  runExampleSyntax (append_to'' ())
+  runExampleSyntax bracketing
+  runExampleSyntax (indentSpaces 2 append_to')
+  runExampleSyntax (indentTabs append_to')
+  runExampleScope (rewrite optimize_tr fact_tr)
+  runExampleSyntax (rewrite optimize_tr spin)
+  runExampleSyntax (rewrite optimize_tr yes)
+  runExampleSyntax badly_scoped
+  runExampleScope badly_scoped

--- a/hpython.cabal
+++ b/hpython.cabal
@@ -22,6 +22,8 @@ library
                      , Language.Python.Internal.Parse
                      , Language.Python.Internal.Render
                      , Language.Python.Internal.Syntax
+                     , Language.Python.Validate.Scope
+                     , Language.Python.Validate.Scope.Error
                      , Language.Python.Validate.Syntax
                      , Language.Python.Validate.Syntax.Error
                      , Language.Python.Validate.Indentation

--- a/hpython.cabal
+++ b/hpython.cabal
@@ -34,6 +34,7 @@ library
                      , parsers
                      , trifecta
                      , mtl
+                     , bytestring-trie >=0.2
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -O2

--- a/hpython.nix
+++ b/hpython.nix
@@ -1,5 +1,5 @@
-{ mkDerivation, base, hedgehog, lens, mtl, parsers, process, stdenv
-, transformers, trifecta, type-level-sets
+{ mkDerivation, base, bytestring-trie, hedgehog, lens, mtl, parsers
+, process, stdenv, transformers, trifecta, type-level-sets
 }:
 mkDerivation {
   pname = "hpython";
@@ -8,7 +8,7 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    base lens mtl parsers trifecta type-level-sets
+    base bytestring-trie lens mtl parsers trifecta type-level-sets
   ];
   executableHaskellDepends = [ base lens ];
   testHaskellDepends = [ base hedgehog lens process transformers ];

--- a/src/Language/Python/Internal/Optics.hs
+++ b/src/Language/Python/Internal/Optics.hs
@@ -117,3 +117,5 @@ instance HasNewlines Statement where
       Assign{} -> pure s
       Pass{} -> pure s
       Break{} -> pure s
+      Global{} -> pure s
+      Nonlocal{} -> pure s

--- a/src/Language/Python/Internal/Optics.hs
+++ b/src/Language/Python/Internal/Optics.hs
@@ -119,3 +119,4 @@ instance HasNewlines Statement where
       Break{} -> pure s
       Global{} -> pure s
       Nonlocal{} -> pure s
+      Del{} -> pure s

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -101,6 +101,13 @@ renderCommaSep f (CommaSepMany a ws1 ws2 c) =
   foldMap renderWhitespace ws1 <> "," <> foldMap renderWhitespace ws2 <>
   renderCommaSep f c
 
+renderCommaSep1 :: (a -> String) -> CommaSep1 a -> String
+renderCommaSep1 f (CommaSepOne1 a) = f a
+renderCommaSep1 f (CommaSepMany1 a ws1 ws2 c) =
+  f a <>
+  foldMap renderWhitespace ws1 <> "," <> foldMap renderWhitespace ws2 <>
+  renderCommaSep1 f c
+
 renderIdent :: Ident v a -> String
 renderIdent = _identValue
 
@@ -198,6 +205,10 @@ renderStatement (Assign _ lvalue ws1 ws2 rvalue) =
   foldMap renderWhitespace ws2 <> renderExpr rvalue
 renderStatement (Pass _) = OneLine "pass"
 renderStatement (Break _) = OneLine "break"
+renderStatement (Global _ ws ids) =
+  OneLine $ "global" <> foldMap renderWhitespace ws <> renderCommaSep1 renderIdent ids
+renderStatement (Nonlocal _ ws ids) =
+  OneLine $ "nonlocal" <> foldMap renderWhitespace ws <> renderCommaSep1 renderIdent ids
 
 renderArgs :: CommaSep (Arg v a) -> String
 renderArgs a = "(" <> renderCommaSep go a <> ")"

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -209,6 +209,8 @@ renderStatement (Global _ ws ids) =
   OneLine $ "global" <> foldMap renderWhitespace ws <> renderCommaSep1 renderIdent ids
 renderStatement (Nonlocal _ ws ids) =
   OneLine $ "nonlocal" <> foldMap renderWhitespace ws <> renderCommaSep1 renderIdent ids
+renderStatement (Del _ ws ids) =
+  OneLine $ "del" <> foldMap renderWhitespace ws <> renderCommaSep1 renderIdent ids
 
 renderArgs :: CommaSep (Arg v a) -> String
 renderArgs a = "(" <> renderCommaSep go a <> ")"

--- a/src/Language/Python/Internal/Syntax.hs
+++ b/src/Language/Python/Internal/Syntax.hs
@@ -101,6 +101,12 @@ data Param (v :: [*]) a
   , _unsafeKeywordParamExpr :: Expr v a
   }
   deriving (Eq, Show)
+paramAnn :: Lens' (Param v a) a
+paramAnn = lens _paramAnn (\s a -> s { _paramAnn = a})
+
+paramName :: Lens (Param v a) (Param '[] a) (Ident v a) (Ident v a)
+paramName = lens _paramName (\s a -> coerce $ s { _paramName = a})
+
 instance HasExprs Param where
   _Exprs f (KeywordParam a name ws1 ws2 expr) =
     KeywordParam a (coerce name) <$> pure ws1 <*> pure ws2 <*> f expr

--- a/src/Language/Python/Internal/Syntax.hs
+++ b/src/Language/Python/Internal/Syntax.hs
@@ -154,6 +154,7 @@ instance HasBlocks Statement where
   _Blocks _ s@Break{} = pure $ coerce s
   _Blocks _ s@Global{} = pure $ coerce s
   _Blocks _ s@Nonlocal{} = pure $ coerce s
+  _Blocks _ s@Del{} = pure $ coerce s
 
 data Newline = CR | LF | CRLF deriving (Eq, Show)
 
@@ -179,6 +180,7 @@ data Statement (v :: [*]) a
   | Break a
   | Global a (NonEmpty Whitespace) (CommaSep1 (Ident v a))
   | Nonlocal a (NonEmpty Whitespace) (CommaSep1 (Ident v a))
+  | Del a (NonEmpty Whitespace) (CommaSep1 (Ident v a))
   deriving (Eq, Show)
 instance Plated (Statement v a) where
   plate f (Fundef a ws1 b ws2 c ws3 ws4 nl sts) =
@@ -196,6 +198,7 @@ instance Plated (Statement v a) where
   plate _ s@Pass{} = pure $ coerce s
   plate _ s@Global{} = pure $ coerce s
   plate _ s@Nonlocal{} = pure $ coerce s
+  plate _ s@Del{} = pure $ coerce s
 
 data CommaSep a
   = CommaSepNone
@@ -288,7 +291,7 @@ instance Num (Expr '[] ()) where
   (-) a = BinOp () a [Space] (Minus ()) [Space]
   signum = undefined
   abs = undefined
-instance Plated (Expr '[] ()) where
+instance Plated (Expr '[] a) where
   plate f (Parens a ws1 e ws2) = Parens a ws1 <$> f e <*> pure ws2
   plate f (List a ws1 exprs ws2) = List a ws1 <$> traverse f exprs <*> pure ws2
   plate f (Deref a expr ws1 ws2 name) =
@@ -349,6 +352,7 @@ instance HasExprs Statement where
   _Exprs _ p@Break{} = pure $ coerce p
   _Exprs _ p@Global{} = pure $ coerce p
   _Exprs _ p@Nonlocal{} = pure $ coerce p
+  _Exprs _ p@Del{} = pure $ coerce p
 
 -- | 'Traversal' over all the statements in a term
 class HasStatements s where

--- a/src/Language/Python/Validate/Indentation.hs
+++ b/src/Language/Python/Validate/Indentation.hs
@@ -105,3 +105,5 @@ validateStatementIndentation e@Expr{} = pure $ coerce e
 validateStatementIndentation e@Assign{} = pure $ coerce e
 validateStatementIndentation e@Pass{} = pure $ coerce e
 validateStatementIndentation e@Break{} = pure $ coerce e
+validateStatementIndentation e@Global{} = pure $ coerce e
+validateStatementIndentation e@Nonlocal{} = pure $ coerce e

--- a/src/Language/Python/Validate/Indentation.hs
+++ b/src/Language/Python/Validate/Indentation.hs
@@ -107,3 +107,4 @@ validateStatementIndentation e@Pass{} = pure $ coerce e
 validateStatementIndentation e@Break{} = pure $ coerce e
 validateStatementIndentation e@Global{} = pure $ coerce e
 validateStatementIndentation e@Nonlocal{} = pure $ coerce e
+validateStatementIndentation e@Del{} = pure $ coerce e

--- a/src/Language/Python/Validate/Scope.hs
+++ b/src/Language/Python/Validate/Scope.hs
@@ -2,15 +2,20 @@
 {-# language GeneralizedNewtypeDeriving #-}
 {-# language TemplateHaskell, TypeFamilies, FlexibleInstances, MultiParamTypeClasses #-}
 {-# language FlexibleContexts #-}
+{-# language RankNTypes #-}
 module Language.Python.Validate.Scope where
 
+import Control.Arrow
+import Control.Applicative
 import Control.Lens.Fold
 import Control.Lens.Getter
+import Control.Lens.Lens
+import Control.Lens.Plated
 import Control.Lens.Review
 import Control.Lens.Setter
 import Control.Lens.TH
+import Control.Lens.Tuple
 import Control.Lens.Traversal
-import Control.Lens.Wrapped
 import Control.Monad.State
 import Data.Coerce
 import Data.Functor.Compose
@@ -21,63 +26,195 @@ import Data.Validate
 
 import qualified Data.Trie as Trie
 
+import Language.Python.Internal.Optics
 import Language.Python.Internal.Syntax
 import Language.Python.Validate.Scope.Error
 
 data Scope
 
-newtype ScopeContext = ScopeContext { unScopeContext :: Trie () }
-  deriving (Eq, Show)
-makeWrapped ''ScopeContext
+data Binding = Clean | Dirty
+  deriving (Eq, Ord, Show)
 
-newtype ValidateScope e a
+data ScopeContext a
+  = ScopeContext
+  { _scGlobalScope :: !(Trie a)
+  , _scLocalScope :: !(Trie a)
+  , _scImmediateScope :: !(Trie a)
+  }
+  deriving (Eq, Show)
+makeLenses ''ScopeContext
+
+initialScopeContext :: ScopeContext a
+initialScopeContext = ScopeContext Trie.empty Trie.empty Trie.empty
+
+newtype ValidateScope ann e a
   = ValidateScope
-  { unValidateScope :: Compose (State ScopeContext) (Validate [e]) a
+  { unValidateScope :: Compose (State (ScopeContext ann)) (Validate [e]) a
   } deriving (Functor, Applicative)
 
-runValidateScope :: ScopeContext -> ValidateScope e a -> Validate [e] a
+runValidateScope :: ScopeContext ann -> ValidateScope ann e a -> Validate [e] a
 runValidateScope ctxt (ValidateScope s) = evalState (getCompose s) ctxt
 
-insertScope :: String -> ValidateScope e ()
-insertScope s =
-  ValidateScope . Compose . fmap pure $
-  modify (over _Wrapped $ Trie.insert (fromString s) ())
+scopeErrors :: [e] -> ValidateScope ann e a
+scopeErrors = ValidateScope . Compose . pure . Failure
 
-inScope :: MonadState ScopeContext m => String -> m Bool
-inScope s = Trie.member (fromString s) . unScopeContext <$> get
+extendScope
+  :: Setter' (ScopeContext ann) (Trie ann)
+  -> [(ann, String)]
+  -> ValidateScope ann e ()
+extendScope l s =
+  ValidateScope . Compose . fmap pure $ do
+  gs <- use scGlobalScope
+  let t = buildTrie gs Trie.empty
+  modify (over l (t `Trie.unionL`))
+  where
+    buildTrie gs t =
+       foldr
+       (\(ann, a) b ->
+          let
+            a' = fromString a
+          in
+            if Trie.member a' gs
+            then b
+            else Trie.insert a' ann b)
+       t
+       s
 
-initialScopeContext :: ScopeContext
-initialScopeContext = ScopeContext Trie.empty
+locallyOver
+  :: Lens' (ScopeContext ann) b
+  -> (b -> b)
+  -> ValidateScope ann e a
+  -> ValidateScope ann e a
+locallyOver l f m =
+  ValidateScope . Compose $ do
+    before <- use l
+    modify (l %~ f)
+    getCompose (unValidateScope m) <* modify (l .~ before)
+
+scopeContext
+  :: Lens' (ScopeContext ann) b
+  -> ValidateScope ann e b
+scopeContext l =
+  ValidateScope . Compose . fmap pure $ use l
+
+bindValidateScope
+  :: ValidateScope ann e a
+  -> (a -> ValidateScope ann e b)
+  -> ValidateScope ann e b
+bindValidateScope v f =
+  ValidateScope . Compose $ do
+    a <- getCompose (unValidateScope v)
+    case a of
+      Failure e -> pure $ Failure e
+      Success x -> getCompose . unValidateScope $ f x
+
+locallyExtendOver
+  :: Lens' (ScopeContext ann) (Trie ann)
+  -> [(ann, String)]
+  -> ValidateScope ann e a
+  -> ValidateScope ann e a
+locallyExtendOver l s m = locallyOver l id $ extendScope l s *> m
+
+inScope :: String -> ValidateScope ann e (Maybe (Binding, ann))
+inScope s =
+  ValidateScope . Compose . fmap pure $ do
+    gs <- use scGlobalScope
+    ls <- use scLocalScope
+    is <- use scImmediateScope
+    let
+      s' = fromString s
+      inls = Trie.lookup s' ls
+      ings = Trie.lookup s' gs
+    pure $
+      ((,) Clean <$> Trie.lookup s' is) <|>
+      (ings *> ((,) Clean <$> inls)) <|>
+      ((,) Clean <$> ings) <|>
+      ((,) Dirty <$> inls)
 
 validateStatementScope
   :: AsScopeError e v a
   => Statement v a
-  -> ValidateScope e (Statement (Nub (Scope ': v)) a)
+  -> ValidateScope a e (Statement (Nub (Scope ': v)) a)
 validateStatementScope (Fundef a ws1 name ws2 params ws3 ws4 nl body) =
-  Fundef a ws1 (coerce name) ws2 <$>
-  traverse validateParamScope params <*>
-  pure ws3 <*>
-  pure ws4 <*>
-  pure nl <*
-  traverse insertScope (toListOf (folded.getting paramName.getting identValue) params) <*
-  insertScope (name ^. getting identValue) <*>
-  validateBlockScope body
+  (locallyOver scLocalScope (const Trie.empty) $
+   locallyOver scImmediateScope (const Trie.empty) $
+     Fundef a ws1 (coerce name) ws2 <$>
+     traverse validateParamScope params <*>
+     pure ws3 <*>
+     pure ws4 <*>
+     pure nl <*>
+     locallyExtendOver
+       scGlobalScope
+       ((_identAnnotation &&& _identValue) name :
+         toListOf (folded.getting paramName.to (_identAnnotation &&& _identValue)) params)
+       (validateBlockScope body)) <*
+  extendScope scLocalScope [(_identAnnotation &&& _identValue) name] <*
+  extendScope scImmediateScope [(_identAnnotation &&& _identValue) name]
+validateStatementScope (Return a ws e) = Return a ws <$> validateExprScope e
+validateStatementScope (Expr a e) = Expr a <$> validateExprScope e
+validateStatementScope (If a ws1 e ws2 ws3 nl b melse) =
+  scopeContext scLocalScope `bindValidateScope` (\ls ->
+  scopeContext scImmediateScope `bindValidateScope` (\is ->
+  locallyOver scGlobalScope (`Trie.unionR` Trie.unionR ls is) $
+  locallyOver scImmediateScope (const Trie.empty)
+    (If a ws1 <$>
+     validateExprScope e <*>
+     pure ws2 <*>
+     pure ws3 <*>
+     pure nl <*>
+     validateBlockScope b <*>
+     traverseOf (traverse._4) validateBlockScope melse)))
+validateStatementScope (While a ws1 e ws2 ws3 nl b) =
+  scopeContext scLocalScope `bindValidateScope` (\ls ->
+  scopeContext scImmediateScope `bindValidateScope` (\is ->
+  locallyOver scGlobalScope (`Trie.unionR` Trie.unionR ls is) $
+  locallyOver scImmediateScope (const Trie.empty)
+    (While a ws1 <$>
+     validateExprScope e <*>
+     pure ws2 <*>
+     pure ws3 <*>
+     pure nl <*>
+     validateBlockScope b)))
+validateStatementScope (Assign a l ws1 ws2 r) =
+  let
+    ls = l ^.. unvalidated.cosmos._Ident._2.to (_identAnnotation &&& _identValue)
+  in
+  (Assign a (coerce l) ws1 ws2 <$> validateExprScope r) <*
+  extendScope scLocalScope ls <*
+  extendScope scImmediateScope ls
+validateStatementScope (Global a _ _) = scopeErrors [_FoundGlobal # a]
+validateStatementScope (Nonlocal a _ _) = scopeErrors [_FoundNonlocal # a]
+validateStatementScope (Del a ws cs) =
+  scopeErrors [_FoundDel # a] <*>
+  traverse validateIdentScope cs
+validateStatementScope s@Pass{} = pure $ coerce s
+validateStatementScope s@Break{} = pure $ coerce s
 
 validateIdentScope
   :: AsScopeError e v a
   => Ident v a
-  -> ValidateScope e (Ident (Nub (Scope ': v)) a)
+  -> ValidateScope a e (Ident (Nub (Scope ': v)) a)
 validateIdentScope i@(MkIdent a s) =
-  ValidateScope . Compose $ do
-    res <- inScope s
-    if res
-      then pure . pure $ MkIdent a s
-      else pure $ Failure [_NotInScope # i]
+  inScope s `bindValidateScope`
+  \context ->
+  case context of
+    Just (Clean, _) -> pure $ MkIdent a s
+    Just (Dirty, ann)-> scopeErrors [_FoundDynamic # (ann, i)]
+    Nothing -> scopeErrors [_NotInScope # i]
+
+validateArgScope
+  :: AsScopeError e v a
+  => Arg v a
+  -> ValidateScope a e (Arg (Nub (Scope ': v)) a)
+validateArgScope (PositionalArg a e) =
+  PositionalArg a <$> validateExprScope e
+validateArgScope (KeywordArg a ident ws1 ws2 expr) =
+  KeywordArg a (coerce ident) ws1 ws2 <$> validateExprScope expr
 
 validateParamScope
   :: AsScopeError e v a
   => Param v a
-  -> ValidateScope e (Param (Nub (Scope ': v)) a)
+  -> ValidateScope a e (Param (Nub (Scope ': v)) a)
 validateParamScope (PositionalParam a ident) =
   pure . PositionalParam a $ coerce ident
 validateParamScope (KeywordParam a ident ws1 ws2 expr) =
@@ -86,11 +223,47 @@ validateParamScope (KeywordParam a ident ws1 ws2 expr) =
 validateBlockScope
   :: AsScopeError e v a
   => Block v a
-  -> ValidateScope e (Block (Nub (Scope ': v)) a)
-validateBlockScope = _
+  -> ValidateScope a e (Block (Nub (Scope ': v)) a)
+validateBlockScope (Block b) =
+  Block <$> traverseOf (traverse._3) validateStatementScope b
 
 validateExprScope
   :: AsScopeError e v a
   => Expr v a
-  -> ValidateScope e (Expr (Nub (Scope ': v)) a)
-validateExprScope = _
+  -> ValidateScope a e (Expr (Nub (Scope ': v)) a)
+validateExprScope (List a ws1 es ws2) =
+  List a ws1 <$>
+  traverse validateExprScope es <*>
+  pure ws2
+validateExprScope (Deref a e ws1 ws2 r) =
+  Deref a <$>
+  validateExprScope e <*>
+  pure ws1 <*>
+  pure ws2 <*>
+  validateIdentScope r
+validateExprScope (Call a e ws1 as) =
+  Call a <$>
+  validateExprScope e <*>
+  pure ws1 <*>
+  traverse validateArgScope as
+validateExprScope (BinOp a l ws1 op ws2 r) =
+  BinOp a <$>
+  validateExprScope l <*>
+  pure ws1 <*>
+  pure op <*>
+  pure ws2 <*>
+  validateExprScope r
+validateExprScope (Negate a ws e) =
+  Negate a ws <$>
+  validateExprScope e
+validateExprScope (Parens a ws1 e ws2) =
+  Parens a ws1 <$>
+  validateExprScope e <*>
+  pure ws2
+validateExprScope (Ident a i) =
+  Ident a <$>
+  validateIdentScope i
+validateExprScope e@None{} = pure $ coerce e
+validateExprScope e@Int{} = pure $ coerce e
+validateExprScope e@Bool{} = pure $ coerce e
+validateExprScope e@String{} = pure $ coerce e

--- a/src/Language/Python/Validate/Scope.hs
+++ b/src/Language/Python/Validate/Scope.hs
@@ -1,0 +1,96 @@
+{-# language DataKinds, TypeOperators #-}
+{-# language GeneralizedNewtypeDeriving #-}
+{-# language TemplateHaskell, TypeFamilies, FlexibleInstances, MultiParamTypeClasses #-}
+{-# language FlexibleContexts #-}
+module Language.Python.Validate.Scope where
+
+import Control.Lens.Fold
+import Control.Lens.Getter
+import Control.Lens.Review
+import Control.Lens.Setter
+import Control.Lens.TH
+import Control.Lens.Traversal
+import Control.Lens.Wrapped
+import Control.Monad.State
+import Data.Coerce
+import Data.Functor.Compose
+import Data.String
+import Data.Type.Set
+import Data.Trie (Trie)
+import Data.Validate
+
+import qualified Data.Trie as Trie
+
+import Language.Python.Internal.Syntax
+import Language.Python.Validate.Scope.Error
+
+data Scope
+
+newtype ScopeContext = ScopeContext { unScopeContext :: Trie () }
+  deriving (Eq, Show)
+makeWrapped ''ScopeContext
+
+newtype ValidateScope e a
+  = ValidateScope
+  { unValidateScope :: Compose (State ScopeContext) (Validate [e]) a
+  } deriving (Functor, Applicative)
+
+runValidateScope :: ScopeContext -> ValidateScope e a -> Validate [e] a
+runValidateScope ctxt (ValidateScope s) = evalState (getCompose s) ctxt
+
+insertScope :: String -> ValidateScope e ()
+insertScope s =
+  ValidateScope . Compose . fmap pure $
+  modify (over _Wrapped $ Trie.insert (fromString s) ())
+
+inScope :: MonadState ScopeContext m => String -> m Bool
+inScope s = Trie.member (fromString s) . unScopeContext <$> get
+
+initialScopeContext :: ScopeContext
+initialScopeContext = ScopeContext Trie.empty
+
+validateStatementScope
+  :: AsScopeError e v a
+  => Statement v a
+  -> ValidateScope e (Statement (Nub (Scope ': v)) a)
+validateStatementScope (Fundef a ws1 name ws2 params ws3 ws4 nl body) =
+  Fundef a ws1 (coerce name) ws2 <$>
+  traverse validateParamScope params <*>
+  pure ws3 <*>
+  pure ws4 <*>
+  pure nl <*
+  traverse insertScope (toListOf (folded.getting paramName.getting identValue) params) <*
+  insertScope (name ^. getting identValue) <*>
+  validateBlockScope body
+
+validateIdentScope
+  :: AsScopeError e v a
+  => Ident v a
+  -> ValidateScope e (Ident (Nub (Scope ': v)) a)
+validateIdentScope i@(MkIdent a s) =
+  ValidateScope . Compose $ do
+    res <- inScope s
+    if res
+      then pure . pure $ MkIdent a s
+      else pure $ Failure [_NotInScope # i]
+
+validateParamScope
+  :: AsScopeError e v a
+  => Param v a
+  -> ValidateScope e (Param (Nub (Scope ': v)) a)
+validateParamScope (PositionalParam a ident) =
+  pure . PositionalParam a $ coerce ident
+validateParamScope (KeywordParam a ident ws1 ws2 expr) =
+  KeywordParam a (coerce ident) ws1 ws2 <$> validateExprScope expr
+
+validateBlockScope
+  :: AsScopeError e v a
+  => Block v a
+  -> ValidateScope e (Block (Nub (Scope ': v)) a)
+validateBlockScope = _
+
+validateExprScope
+  :: AsScopeError e v a
+  => Expr v a
+  -> ValidateScope e (Expr (Nub (Scope ': v)) a)
+validateExprScope = _

--- a/src/Language/Python/Validate/Scope/Error.hs
+++ b/src/Language/Python/Validate/Scope/Error.hs
@@ -1,0 +1,14 @@
+{-# language DataKinds, KindSignatures #-}
+{-# language TemplateHaskell #-}
+{-# language MultiParamTypeClasses, FunctionalDependencies, FlexibleInstances #-}
+module Language.Python.Validate.Scope.Error where
+
+import Control.Lens.TH
+import Language.Python.Internal.Syntax
+
+data ScopeError (v :: [*]) a
+  = FoundNonlocal a
+  | FoundGlobal a
+  | NotInScope (Ident v a)
+
+makeClassyPrisms ''ScopeError

--- a/src/Language/Python/Validate/Scope/Error.hs
+++ b/src/Language/Python/Validate/Scope/Error.hs
@@ -9,6 +9,9 @@ import Language.Python.Internal.Syntax
 data ScopeError (v :: [*]) a
   = FoundNonlocal a
   | FoundGlobal a
+  | FoundDel a
+  | FoundDynamic a (Ident v a)
   | NotInScope (Ident v a)
+  deriving (Eq, Show)
 
 makeClassyPrisms ''ScopeError

--- a/src/Language/Python/Validate/Syntax.hs
+++ b/src/Language/Python/Validate/Syntax.hs
@@ -34,6 +34,13 @@ data SyntaxContext
   , _inFunction :: Bool
   }
 
+initialSyntaxContext :: SyntaxContext
+initialSyntaxContext =
+  SyntaxContext
+  { _inLoop = False
+  , _inFunction = False
+  }
+
 class StartsWith s where
   startsWith :: s -> Maybe Char
 
@@ -246,6 +253,8 @@ validateStatementSyntax ctxt (Global a ws ids) =
   Global a ws <$> traverse validateIdent ids
 validateStatementSyntax ctxt (Nonlocal a ws ids) =
   Nonlocal a ws <$> traverse validateIdent ids
+validateStatementSyntax ctxt (Del a ws ids) =
+  Del a ws <$> traverse validateIdent ids
 
 canAssignTo :: Expr v a -> Bool
 canAssignTo None{} = False

--- a/src/Language/Python/Validate/Syntax.hs
+++ b/src/Language/Python/Validate/Syntax.hs
@@ -242,6 +242,10 @@ validateStatementSyntax ctxt p@Pass{} = pure $ coerce p
 validateStatementSyntax ctxt (Break a)
   | _inLoop ctxt = pure $ Break a
   | otherwise = Failure [_BreakOutsideLoop # a]
+validateStatementSyntax ctxt (Global a ws ids) =
+  Global a ws <$> traverse validateIdent ids
+validateStatementSyntax ctxt (Nonlocal a ws ids) =
+  Nonlocal a ws <$> traverse validateIdent ids
 
 canAssignTo :: Expr v a -> Bool
 canAssignTo None{} = False

--- a/test/Generators.hs
+++ b/test/Generators.hs
@@ -230,6 +230,9 @@ statementSize (While _ _ a _ _ _ b) = 1 + exprSize a + blockSize b
 statementSize (Assign _ a _ _ b) = 1 + exprSize a + exprSize b
 statementSize Pass{} = 1
 statementSize Break{} = 1
+statementSize (Global _ _ cs) = Size $ 1 + length cs
+statementSize (Nonlocal _ _ cs) = Size $ 1 + length cs
+statementSize (Del _ _ cs) = Size $ 1 + length cs
 
 genSizedStatement :: MonadGen m => m (Statement '[] ())
 genSizedStatement = Gen.sized $ \n ->

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -8,6 +8,7 @@ import Language.Python.Validate.Indentation.Error
 import Language.Python.Validate.Syntax
 import Language.Python.Validate.Syntax.Error
 import Generators
+import Scope
 
 import Control.Lens
 import Control.Monad.IO.Class
@@ -18,6 +19,7 @@ import System.Exit
 import System.Process
 
 import Hedgehog
+import qualified Hedgehog.Gen as Gen
 
 validateExprSyntax'
   :: Expr '[Indentation] a
@@ -58,7 +60,7 @@ runPython3 shouldSucceed str = do
 syntax_expr :: Property
 syntax_expr =
   property $ do
-    ex <- forAll genSizedExpr
+    ex <- forAll $ Gen.resize 300 genSizedExpr
     let rex = renderExpr ex
     shouldSucceed <-
       case validateExprIndentation' ex of
@@ -75,7 +77,7 @@ syntax_expr =
 syntax_statement :: Property
 syntax_statement =
   property $ do
-    st <- forAll genSizedStatement
+    st <- forAll $ Gen.resize 300 genSizedStatement
     let rst = renderLines $ renderStatement st
     shouldSucceed <-
       case validateStatementIndentation' st of
@@ -88,5 +90,6 @@ syntax_statement =
     runPython3 shouldSucceed rst
 
 main = do
-  check $ withTests 1000 syntax_expr
-  check $ withTests 1000 syntax_statement
+  check $ withTests 200 syntax_expr
+  check $ withTests 200 syntax_statement
+  checkParallel scopeTests

--- a/test/Scope.hs
+++ b/test/Scope.hs
@@ -21,6 +21,7 @@ scopeTests =
   , ("Scope test 2", withTests 1 test_2)
   , ("Scope test 3", withTests 1 test_3)
   , ("Scope test 4", withTests 1 test_4)
+  , ("Scope test 5", withTests 1 test_5)
   ]
 
 validate
@@ -90,3 +91,15 @@ test_4 =
     res <- validate expr
     annotateShow res
     res === Failure [NotInScope (MkIdent () "g")]
+
+test_5 :: Property
+test_5 =
+  property $ do
+    let
+      expr =
+        def_ "test" [p_ "a"]
+          [ def_ "f" [k_ "b" (var_ "c")] [ pass_ ]
+          ]
+    res <- validate expr
+    annotateShow res
+    res === Failure [NotInScope (MkIdent () "c")]

--- a/test/Scope.hs
+++ b/test/Scope.hs
@@ -1,0 +1,92 @@
+{-# language OverloadedStrings, OverloadedLists, DataKinds #-}
+module Scope (scopeTests) where
+
+import Control.Lens (has)
+import Data.Validate
+import Language.Python.Validate.Syntax
+import Language.Python.Validate.Syntax.Error
+import Language.Python.Validate.Indentation
+import Language.Python.Validate.Indentation.Error
+import Language.Python.Validate.Scope
+import Language.Python.Validate.Scope.Error
+import Language.Python.Internal.Syntax
+import Language.Python.Syntax
+
+import Hedgehog
+
+scopeTests :: Group
+scopeTests =
+  Group "Scope tests"
+  [ ("Scope test 1", withTests 1 test_1)
+  , ("Scope test 2", withTests 1 test_2)
+  , ("Scope test 3", withTests 1 test_3)
+  , ("Scope test 4", withTests 1 test_4)
+  ]
+
+validate
+  :: Statement '[] ()
+  -> PropertyT IO
+       (Validate
+          [ScopeError '[Syntax, Indentation] ()]
+          (Statement '[Scope, Syntax, Indentation] ()))
+validate x =
+  case validateStatementIndentation x of
+    Failure errs -> do
+      annotateShow (errs :: [IndentationError '[] ()])
+      failure
+    Success a ->
+      case validateStatementSyntax initialSyntaxContext a of
+        Failure errs -> do
+          annotateShow (errs :: [SyntaxError '[Indentation] ()])
+          failure
+        Success a' -> pure $ runValidateScope initialScopeContext (validateStatementScope a')
+
+test_1 :: Property
+test_1 =
+  property $ do
+    let
+      expr =
+        def_ "test" [p_ "a", p_ "b"]
+          [ if_ true_ [ var_ "c" .= 2]
+          , return_ $ var_ "a" .+ var_ "b" .+ var_ "c"
+          ]
+    res <- validate expr
+    res === Failure [FoundDynamic () (MkIdent () "c")]
+
+test_2 :: Property
+test_2 =
+  property $ do
+    let
+      expr =
+        def_ "test" [p_ "a", p_ "b"]
+          [ var_ "c" .= 0
+          , if_ true_ [ var_ "c" .= 2]
+          , return_ $ var_ "a" .+ var_ "b" .+ var_ "c"
+          ]
+    res <- validate expr
+    annotateShow res
+    assert $ has _Success res
+
+test_3 :: Property
+test_3 =
+  property $ do
+    let
+      expr =
+        def_ "test" [p_ "a", p_ "b"]
+          [ return_ $ var_ "a" .+ var_ "b" .+ var_ "c" ]
+    res <- validate expr
+    annotateShow res
+    res === Failure [NotInScope (MkIdent () "c")]
+
+test_4 :: Property
+test_4 =
+  property $ do
+    let
+      expr =
+        def_ "test" [p_ "a", p_ "b"]
+          [ def_ "f" [] [ def_ "g" [] [pass_] ]
+          , expr_ $ call_ (var_ "f") []
+          ]
+    res <- validate expr
+    annotateShow res
+    res === Failure [NotInScope (MkIdent () "g")]


### PR DESCRIPTION
A Python program can be badly-scoped in five ways:

1. It contains `global` statements
2. It contains `nonlocal` statements
3. It contains `del` statements (this will need to be refined)
4. Variables declared inside control statements are referenced from the outside
5. The variable is not in scope

If anything from 1-4 are present in a module then you can't generally decide if any particular variable is in scope, because the scoping is determined by the execution of the program. If 1-4 are false, then static scope checking is sound.