### PR TITLE
Made String -> Python more granular, and reworked indentation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,13 +7,24 @@ let
   f = import ./hpython.nix;
 
 
-  haskellPackages = if compiler == "default"
-                       then pkgs.haskellPackages
-                       else pkgs.haskell.packages.${compiler};
+  haskellPackages =
+    (if compiler == "default"
+     then pkgs.haskellPackages
+     else pkgs.haskell.packages.${compiler}).override {
+       overrides = self: super: {
+         free = self.free_5_0_1;
+         kan-extensions = self.kan-extensions_5_1;
+         semigroupoids = self.semigroupoids_5_2_2;
+         adjunctions = self.adjunctions_4_4;
+         lens = self.lens_4_16;
+       };
+     };
 
   type-level-sets = haskellPackages.callPackage ./nix/type-level-sets.nix {};
 
-  drv = haskellPackages.callPackage f { inherit type-level-sets; };
+  drv = haskellPackages.callPackage f {
+    inherit type-level-sets;
+  };
 
 in
 

--- a/example/Indentation.hs
+++ b/example/Indentation.hs
@@ -9,7 +9,7 @@ import Language.Python.Internal.Optics
 import Language.Python.Internal.Syntax
 
 indentSpaces :: Natural -> Statement '[] a -> Statement '[] a
-indentSpaces n = transform (_Indents .~ replicate (fromIntegral n) Space)
+indentSpaces n = transform (_Indent .~ replicate (fromIntegral n) Space)
 
 indentTabs :: Statement '[] a -> Statement '[] a
-indentTabs = transform (_Indents .~ [Tab])
+indentTabs = transform (_Indent .~ [Tab])

--- a/example/Programs.hs
+++ b/example/Programs.hs
@@ -2,6 +2,8 @@
 {-# language FlexibleContexts #-}
 module Programs where
 
+import Control.Lens.Getter ((^.))
+import Control.Lens.Iso (from)
 import Language.Python.Internal.Syntax
 import Language.Python.Syntax
 
@@ -15,20 +17,20 @@ import Language.Python.Syntax
 -- Written without the DSL
 append_to =
   CompoundStatement $
-  Fundef ()
+  Fundef (Indents [] ()) ()
     [Space]
     "append_to"
     []
     ( CommaSepMany (PositionalParam () "element") [Space] $
-      CommaSepOne (KeywordParam () "to" [] (List () [] CommaSepNone []))
+      CommaSepOne (KeywordParam () "to" [] (List () [] Nothing []))
     )
     []
     []
     LF
     (Block
-     [ ( ()
-       , replicate 4 Space
-       , Right $ SmallStatements
+     [ Right $
+       SmallStatements
+         (Indents [replicate 4 Space ^. from indentWhitespaces] ())
          (Expr () $
           Call ()
             (Deref () (Ident () "to") [] "append")
@@ -37,12 +39,14 @@ append_to =
             [])
          []
          Nothing
-         LF
-       )
-     , ( ()
-       , replicate 4 Space
-       , Right $ SmallStatements (Return () [Space] (Ident () "to")) [] Nothing LF
-       )
+         (Just LF)
+     , Right $
+       SmallStatements
+         (Indents [replicate 4 Space ^. from indentWhitespaces] ())
+         (Return () [Space] (Ident () "to"))
+         []
+         Nothing
+         (Just LF)
      ])
 
 -- |
@@ -101,12 +105,12 @@ yes =
 everything =
   Module
     [ Right append_to
-    , Left ([], Nothing, LF)
+    , Left (Indents [] (), Nothing, Just LF)
     , Right append_to'
-    , Left ([], Nothing, LF)
+    , Left (Indents [] (), Nothing, Just LF)
     , Right fact_tr
-    , Left ([], Nothing, LF)
+    , Left (Indents [] (), Nothing, Just LF)
     , Right spin
-    , Left ([], Nothing, LF)
+    , Left (Indents [] (), Nothing, Just LF)
     , Right yes
     ]

--- a/hpython.cabal
+++ b/hpython.cabal
@@ -50,6 +50,7 @@ library
                      , containers >=0.5 && <0.6
                      , deriving-compat >=0.4 && <0.5
                      , semigroupoids >=5.2.2 && <5.3
+                     , fingertree >=0.1 && <0.2
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -O2

--- a/hpython.cabal
+++ b/hpython.cabal
@@ -48,6 +48,8 @@ library
                      , mtl
                      , bytestring-trie >=0.2
                      , containers >=0.5 && <0.6
+                     , deriving-compat >=0.4 && <0.5
+                     , semigroupoids >=5.2.2 && <5.3
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -O2
@@ -77,6 +79,7 @@ test-suite hpython-tests
   other-modules:       Generators.General
                      , Generators.Common
                      , Generators.Correct
+                     , LexerParser
                      , Scope
                      , Roundtrip
   hs-source-dirs:      test
@@ -88,6 +91,7 @@ test-suite hpython-tests
                      , lens
                      , mtl
                      , process
+                     , semigroupoids >=5.2.2 && <5.3
                      , transformers
                      , trifecta
   default-language:    Haskell2010

--- a/hpython.cabal
+++ b/hpython.cabal
@@ -18,6 +18,7 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Data.Validate
                      , Language.Python.Syntax
+                     , Language.Python.Internal.Lexer
                      , Language.Python.Internal.Optics
                      , Language.Python.Internal.Parse
                      , Language.Python.Internal.Render

--- a/hpython.cabal
+++ b/hpython.cabal
@@ -47,6 +47,7 @@ library
                      , trifecta
                      , mtl
                      , bytestring-trie >=0.2
+                     , containers >=0.5 && <0.6
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -O2

--- a/hpython.cabal
+++ b/hpython.cabal
@@ -79,6 +79,7 @@ test-suite hpython-tests
   other-modules:       Generators.General
                      , Generators.Common
                      , Generators.Correct
+                     , Helpers
                      , LexerParser
                      , Scope
                      , Roundtrip

--- a/hpython.nix
+++ b/hpython.nix
@@ -1,6 +1,6 @@
-{ mkDerivation, base, bytestring-trie, containers, directory
-, filepath, hedgehog, lens, mtl, parsers, process, stdenv
-, transformers, trifecta, type-level-sets
+{ mkDerivation, base, bytestring-trie, containers, deriving-compat
+, directory, filepath, hedgehog, lens, mtl, parsers, process
+, semigroupoids, stdenv, transformers, trifecta, type-level-sets
 }:
 mkDerivation {
   pname = "hpython";
@@ -9,13 +9,13 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    base bytestring-trie containers lens mtl parsers trifecta
-    type-level-sets
+    base bytestring-trie containers deriving-compat lens mtl parsers
+    semigroupoids trifecta type-level-sets
   ];
   executableHaskellDepends = [ base lens ];
   testHaskellDepends = [
-    base directory filepath hedgehog lens mtl process transformers
-    trifecta
+    base directory filepath hedgehog lens mtl process semigroupoids
+    transformers trifecta
   ];
   license = stdenv.lib.licenses.bsd3;
 }

--- a/hpython.nix
+++ b/hpython.nix
@@ -1,6 +1,7 @@
 { mkDerivation, base, bytestring-trie, containers, deriving-compat
-, directory, filepath, hedgehog, lens, mtl, parsers, process
-, semigroupoids, stdenv, transformers, trifecta, type-level-sets
+, directory, filepath, fingertree, hedgehog, lens, mtl, parsers
+, process, semigroupoids, stdenv, transformers, trifecta
+, type-level-sets
 }:
 mkDerivation {
   pname = "hpython";
@@ -9,8 +10,8 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    base bytestring-trie containers deriving-compat lens mtl parsers
-    semigroupoids trifecta type-level-sets
+    base bytestring-trie containers deriving-compat fingertree lens mtl
+    parsers semigroupoids trifecta type-level-sets
   ];
   executableHaskellDepends = [ base lens ];
   testHaskellDepends = [

--- a/hpython.nix
+++ b/hpython.nix
@@ -1,5 +1,5 @@
-{ mkDerivation, base, bytestring-trie, directory, filepath
-, hedgehog, lens, mtl, parsers, process, stdenv, these
+{ mkDerivation, base, bytestring-trie, containers, directory
+, filepath, hedgehog, lens, mtl, parsers, process, stdenv
 , transformers, trifecta, type-level-sets
 }:
 mkDerivation {
@@ -9,7 +9,7 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    base bytestring-trie lens mtl parsers these trifecta
+    base bytestring-trie containers lens mtl parsers trifecta
     type-level-sets
   ];
   executableHaskellDepends = [ base lens ];

--- a/src/Language/Python/Internal/Lexer.hs
+++ b/src/Language/Python/Internal/Lexer.hs
@@ -46,6 +46,8 @@ data PyToken a
   | TkAnd a
   | TkIs a
   | TkNot a
+  | TkGlobal a
+  | TkDel a
   | TkInt Integer a
   | TkFloat Integer (Maybe Integer) a
   | TkIdent String a
@@ -98,6 +100,8 @@ pyTokenAnn tk =
     TkAnd a -> a
     TkIs a -> a
     TkNot a -> a
+    TkGlobal a -> a
+    TkDel a -> a
     TkPlus a -> a
     TkMinus a -> a
     TkIf a -> a
@@ -217,6 +221,8 @@ parseToken =
     , string "and" $> TkAnd
     , string "is" $> TkIs
     , string "not" $> TkNot
+    , string "global" $> TkGlobal
+    , string "del" $> TkDel
     , (\a b -> maybe (TkInt a) (TkFloat a) b) <$>
         fmap read (some digit) <*>
         optional (char '.' *> optional (read <$> some digit))

--- a/src/Language/Python/Internal/Lexer.hs
+++ b/src/Language/Python/Internal/Lexer.hs
@@ -244,7 +244,10 @@ parseToken =
            TkShortString sp SingleQuote <$> manyTill stringChar (char '\''))
     , TkComment <$ char '#' <*> many (noneOf "\r\n") <*> parseNewline
     , char ',' $> TkComma
-    , TkIdent <$> some (letter <|> char '_')
+    , fmap TkIdent $
+      (:) <$>
+      (letter <|> char '_') <*>
+      many (letter <|> digit <|> char '_')
     ]
 
 tokenize :: String -> Trifecta.Result [PyToken Caret]

--- a/src/Language/Python/Internal/Lexer.hs
+++ b/src/Language/Python/Internal/Lexer.hs
@@ -42,6 +42,8 @@ data PyToken a
   | TkContinue a
   | TkTrue a
   | TkFalse a
+  | TkOr a
+  | TkAnd a
   | TkInt Integer a
   | TkFloat Integer (Maybe Integer) a
   | TkIdent String a
@@ -90,6 +92,8 @@ pyTokenAnn tk =
     TkContinue a -> a
     TkTrue a -> a
     TkFalse a -> a
+    TkOr a -> a
+    TkAnd a -> a
     TkPlus a -> a
     TkMinus a -> a
     TkIf a -> a
@@ -205,6 +209,8 @@ parseToken =
     , string "continue" $> TkContinue
     , string "True" $> TkTrue
     , string "False" $> TkFalse
+    , string "or" $> TkOr
+    , string "and" $> TkAnd
     , (\a b -> maybe (TkInt a) (TkFloat a) b) <$>
         fmap read (some digit) <*>
         optional (char '.' *> optional (read <$> some digit))

--- a/src/Language/Python/Internal/Lexer.hs
+++ b/src/Language/Python/Internal/Lexer.hs
@@ -48,6 +48,9 @@ data PyToken a
   | TkNot a
   | TkGlobal a
   | TkDel a
+  | TkImport a
+  | TkFrom a
+  | TkAs a
   | TkInt Integer a
   | TkFloat Integer (Maybe Integer) a
   | TkIdent String a
@@ -102,6 +105,9 @@ pyTokenAnn tk =
     TkNot a -> a
     TkGlobal a -> a
     TkDel a -> a
+    TkImport a -> a
+    TkFrom a -> a
+    TkAs a -> a
     TkPlus a -> a
     TkMinus a -> a
     TkIf a -> a
@@ -223,6 +229,9 @@ parseToken =
     , string "not" $> TkNot
     , string "global" $> TkGlobal
     , string "del" $> TkDel
+    , string "import" $> TkImport
+    , string "from" $> TkFrom
+    , string "as" $> TkAs
     , (\a b -> maybe (TkInt a) (TkFloat a) b) <$>
         fmap read (some digit) <*>
         optional (char '.' *> optional (read <$> some digit))

--- a/src/Language/Python/Internal/Lexer.hs
+++ b/src/Language/Python/Internal/Lexer.hs
@@ -463,12 +463,15 @@ indentation lls =
              not (et8 > et8i && et1 > et1i) &&
              not (et8 == et8i && et1 == et1i))
             (throwError TabError)
-          case compare et8 et8i of
-            LT -> (<> [IndentedLine ll]) <$> dedents ann et8
+          let
+            ilSpcs = indentLevel spcs
+            ili = indentLevel i
+          case compare ilSpcs ili of
+            LT -> (<> [IndentedLine ll]) <$> dedents ann ilSpcs
             EQ -> pure [IndentedLine ll]
             GT -> do
               modify $ NonEmpty.cons spcs
-              pure [Indent (et8 - et8i) ann, IndentedLine ll]
+              pure [Indent (ilSpcs - ili) ann, IndentedLine ll]
 
 data Line a
   = Line
@@ -479,7 +482,8 @@ data Line a
   } deriving (Eq, Show)
 
 logicalToLine :: Seq Int -> LogicalLine a -> Line a
-logicalToLine leaps (LogicalLine a b c d) = Line a (splitIndents leaps b) c (snd <$> d)
+logicalToLine leaps (LogicalLine a b c d) =
+  Line a (if all isBlankToken c then [b] else splitIndents leaps b) c (snd <$> d)
 
 newtype Nested a
   = Nested

--- a/src/Language/Python/Internal/Lexer.hs
+++ b/src/Language/Python/Internal/Lexer.hs
@@ -51,6 +51,7 @@ data PyToken a
   | TkImport a
   | TkFrom a
   | TkAs a
+  | TkRaise a
   | TkInt Integer a
   | TkFloat Integer (Maybe Integer) a
   | TkIdent String a
@@ -78,7 +79,7 @@ data PyToken a
   | TkDot a
   | TkPlus a
   | TkMinus a
-  | TkComment String Newline a
+  | TkComment String a
   | TkStar a
   | TkDoubleStar a
   | TkSlash a
@@ -108,6 +109,7 @@ pyTokenAnn tk =
     TkImport a -> a
     TkFrom a -> a
     TkAs a -> a
+    TkRaise a -> a
     TkPlus a -> a
     TkMinus a -> a
     TkIf a -> a
@@ -136,7 +138,7 @@ pyTokenAnn tk =
     TkSemicolon a -> a
     TkComma a -> a
     TkDot a -> a
-    TkComment _ _ a -> a
+    TkComment _ a -> a
     TkStar a -> a
     TkDoubleStar a -> a
     TkSlash a -> a
@@ -232,6 +234,7 @@ parseToken =
     , string "import" $> TkImport
     , string "from" $> TkFrom
     , string "as" $> TkAs
+    , string "raise" $> TkRaise
     , (\a b -> maybe (TkInt a) (TkFloat a) b) <$>
         fmap read (some digit) <*>
         optional (char '.' *> optional (read <$> some digit))
@@ -271,7 +274,9 @@ parseToken =
            manyTill stringChar (string "'''")
            <|>
            TkShortString sp SingleQuote <$> manyTill stringChar (char '\''))
-    , TkComment <$ char '#' <*> many (noneOf "\r\n") <*> parseNewline
+    , TkComment <$
+      char '#' <*>
+      many (noneOf "\r\n")
     , char ',' $> TkComma
     , char '.' $> TkDot
     , fmap TkIdent $

--- a/src/Language/Python/Internal/Lexer.hs
+++ b/src/Language/Python/Internal/Lexer.hs
@@ -54,6 +54,9 @@ data PyToken a
   | TkFrom a
   | TkAs a
   | TkRaise a
+  | TkTry a
+  | TkExcept a
+  | TkFinally a
   | TkInt Integer a
   | TkFloat Integer (Maybe Integer) a
   | TkIdent String a
@@ -112,6 +115,9 @@ pyTokenAnn tk =
     TkFrom a -> a
     TkAs a -> a
     TkRaise a -> a
+    TkTry a -> a
+    TkExcept a -> a
+    TkFinally a -> a
     TkPlus a -> a
     TkMinus a -> a
     TkIf a -> a
@@ -241,6 +247,9 @@ parseToken =
     , string "from" $> TkFrom
     , string "as" $> TkAs
     , string "raise" $> TkRaise
+    , string "try" $> TkTry
+    , string "except" $> TkExcept
+    , string "finally" $> TkFinally
     , (\a b -> maybe (TkInt a) (TkFloat a) b) <$>
         fmap read (some digit) <*>
         optional (char '.' *> optional (read <$> some digit))

--- a/src/Language/Python/Internal/Lexer.hs
+++ b/src/Language/Python/Internal/Lexer.hs
@@ -67,6 +67,8 @@ data PyToken a
   | TkExcept a
   | TkFinally a
   | TkClass a
+  | TkFor a
+  | TkIn a
   | TkInt Integer a
   | TkFloat Integer (Maybe Integer) a
   | TkIdent String a
@@ -129,6 +131,8 @@ pyTokenAnn tk =
     TkExcept a -> a
     TkFinally a -> a
     TkClass a -> a
+    TkFor a -> a
+    TkIn a -> a
     TkPlus a -> a
     TkMinus a -> a
     TkIf a -> a
@@ -267,6 +271,8 @@ parseToken =
     , string "except" $> TkExcept
     , string "finally" $> TkFinally
     , string "class" $> TkClass
+    , string "for" $> TkFor
+    , string "in" $> TkIn
     ] <>
     [ (\a b -> maybe (TkInt a) (TkFloat a) b) <$>
         fmap read (some digit) <*>

--- a/src/Language/Python/Internal/Lexer.hs
+++ b/src/Language/Python/Internal/Lexer.hs
@@ -57,6 +57,7 @@ data PyToken a
   | TkTry a
   | TkExcept a
   | TkFinally a
+  | TkClass a
   | TkInt Integer a
   | TkFloat Integer (Maybe Integer) a
   | TkIdent String a
@@ -118,6 +119,7 @@ pyTokenAnn tk =
     TkTry a -> a
     TkExcept a -> a
     TkFinally a -> a
+    TkClass a -> a
     TkPlus a -> a
     TkMinus a -> a
     TkIf a -> a
@@ -250,6 +252,7 @@ parseToken =
     , string "try" $> TkTry
     , string "except" $> TkExcept
     , string "finally" $> TkFinally
+    , string "class" $> TkClass
     , (\a b -> maybe (TkInt a) (TkFloat a) b) <$>
         fmap read (some digit) <*>
         optional (char '.' *> optional (read <$> some digit))

--- a/src/Language/Python/Internal/Lexer.hs
+++ b/src/Language/Python/Internal/Lexer.hs
@@ -44,6 +44,8 @@ data PyToken a
   | TkFalse a
   | TkOr a
   | TkAnd a
+  | TkIs a
+  | TkNot a
   | TkInt Integer a
   | TkFloat Integer (Maybe Integer) a
   | TkIdent String a
@@ -94,6 +96,8 @@ pyTokenAnn tk =
     TkFalse a -> a
     TkOr a -> a
     TkAnd a -> a
+    TkIs a -> a
+    TkNot a -> a
     TkPlus a -> a
     TkMinus a -> a
     TkIf a -> a
@@ -211,6 +215,8 @@ parseToken =
     , string "False" $> TkFalse
     , string "or" $> TkOr
     , string "and" $> TkAnd
+    , string "is" $> TkIs
+    , string "not" $> TkNot
     , (\a b -> maybe (TkInt a) (TkFloat a) b) <$>
         fmap read (some digit) <*>
         optional (char '.' *> optional (read <$> some digit))
@@ -243,7 +249,7 @@ parseToken =
            <|>
            TkShortString sp DoubleQuote <$> manyTill stringChar (char '"'))
     , do
-        sp <- optional . try $ stringPrefix <* lookAhead (char '"')
+        sp <- optional . try $ stringPrefix <* lookAhead (char '\'')
         char '\'' *>
           (string "''" $>
            TkLongString sp SingleQuote <*>

--- a/src/Language/Python/Internal/Lexer.hs
+++ b/src/Language/Python/Internal/Lexer.hs
@@ -1,0 +1,284 @@
+{-# language DeriveFunctor #-}
+{-# language BangPatterns #-}
+module Language.Python.Internal.Lexer where
+
+import Control.Applicative ((<|>), some, many, optional)
+import Control.Monad (when)
+import Control.Monad.State (StateT, evalStateT, get, modify, put)
+import Control.Monad.Trans (lift)
+import Data.Bifunctor (first)
+import Data.Foldable (asum)
+import Data.Functor (($>))
+import Data.List.NonEmpty (NonEmpty(..))
+import Data.Semigroup ((<>))
+import Text.Trifecta
+  ( DeltaParsing, Caret, Careted(..), char, careted, letter, noneOf, digit, string, manyTill
+  , parseString
+  )
+
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Text.Trifecta as Trifecta
+
+import Language.Python.Internal.Syntax.Whitespace
+  (Newline(..), Whitespace(..), newline)
+
+data QuoteType = SingleQuote | DoubleQuote
+  deriving (Eq, Show)
+
+data PyToken a
+  = TkIf a
+  | TkDef a
+  | TkInt Integer a
+  | TkFloat Integer (Maybe Integer) a
+  | TkIdent String a
+  | TkShortString QuoteType String a
+  | TkLongString QuoteType String a
+  | TkSpace a
+  | TkTab a
+  | TkNewline Newline a
+  | TkLeftBracket a
+  | TkRightBracket a
+  | TkLeftParen a
+  | TkRightParen a
+  | TkLeftBrace a
+  | TkRightBrace a
+  | TkLt a
+  | TkLte a
+  | TkEq a
+  | TkDoubleEq a
+  | TkGt a
+  | TkGte a
+  | TkContinue Newline a
+  | TkColon a
+  | TkComma a
+  | TkPlus a
+  | TkMinus a
+  | TkComment String Newline a
+  | TkStar a
+  | TkDoubleStar a
+  | TkSlash a
+  | TkDoubleSlash a
+  | TkPercent a
+  | TkShiftLeft a
+  | TkShiftRight a
+  deriving (Eq, Show, Functor)
+
+pyTokenAnn :: PyToken a -> a
+pyTokenAnn tk =
+  case tk of
+    TkDef a -> a
+    TkPlus a -> a
+    TkMinus a -> a
+    TkIf a -> a
+    TkInt _ a -> a
+    TkFloat _ _ a -> a
+    TkIdent _ a -> a
+    TkShortString _ _ a -> a
+    TkLongString _ _ a -> a
+    TkSpace a -> a
+    TkTab a -> a
+    TkNewline _ a -> a
+    TkLeftBracket a -> a
+    TkRightBracket a -> a
+    TkLeftParen a -> a
+    TkRightParen a -> a
+    TkLeftBrace a -> a
+    TkRightBrace a -> a
+    TkLt a -> a
+    TkLte a -> a
+    TkEq a -> a
+    TkDoubleEq a -> a
+    TkGt a -> a
+    TkGte a -> a
+    TkContinue _ a -> a
+    TkColon a -> a
+    TkComma a -> a
+    TkComment _ _ a -> a
+    TkStar a -> a
+    TkDoubleStar a -> a
+    TkSlash a -> a
+    TkDoubleSlash a -> a
+    TkPercent a -> a
+    TkShiftLeft a -> a
+    TkShiftRight a -> a
+
+token :: DeltaParsing m => m (PyToken Caret)
+token =
+  fmap (\(f :^ sp) -> f sp) . careted $
+  asum
+    [ string "if" $> TkIf
+    , string "def" $> TkDef
+    , (\a b -> maybe (TkInt a) (TkFloat a) b) <$>
+        fmap read (some digit) <*>
+        optional (char '.' *> optional (read <$> some digit))
+    , char ' ' $> TkSpace
+    , char '\t' $> TkTab
+    , char '\n' $> TkNewline LF
+    , char '\r' *> (char '\n' $> TkNewline CRLF <|> pure (TkNewline CR))
+    , char '[' $> TkLeftBracket
+    , char ']' $> TkRightBracket
+    , char '(' $> TkLeftParen
+    , char ')' $> TkRightParen
+    , char '{' $> TkLeftBrace
+    , char '}' $> TkRightBrace
+    , char '<' *> (char '=' $> TkLte <|> char '<' $> TkShiftLeft <|> pure TkLt)
+    , char '=' *> (char '=' $> TkDoubleEq <|> pure TkEq)
+    , char '>' *> (char '=' $> TkGte <|> char '>' $> TkShiftRight <|> pure TkGt)
+    , char '*' *> (char '*' $> TkDoubleStar <|> pure TkStar)
+    , char '/' *> (char '/' $> TkDoubleSlash <|> pure TkSlash)
+    , char '+' $> TkPlus
+    , char '-' $> TkMinus
+    , char '%' $> TkPercent
+    , char '\\' $> TkContinue <*> newline
+    , char ':' $> TkColon
+    , char '"' *>
+      (string "\"\"" $> TkLongString DoubleQuote <*> manyTill (noneOf "\"") (string "\"\"\"") <|>
+       TkShortString DoubleQuote <$> manyTill (noneOf "\"") (char '"'))
+    , char '\'' *>
+      (string "''" $> TkLongString SingleQuote <*> manyTill (noneOf "\'") (string "'''") <|>
+       TkShortString SingleQuote <$> manyTill (noneOf "\'") (char '\''))
+    , TkComment <$ char '#' <*> many (noneOf "\r\n") <*> newline
+    , char ',' $> TkComma
+    , TkIdent <$> some letter
+    ]
+
+tokenize :: String -> Trifecta.Result [PyToken Caret]
+tokenize = parseString (many token) mempty
+
+data LogicalLine a
+  = LogicalLine
+  { llAnn :: a
+  , llSpaces :: [Whitespace]
+  , llLine :: [PyToken a]
+  , llEnd :: Maybe Newline
+  } deriving (Eq, Show)
+
+spaceToken :: PyToken a -> Maybe Whitespace
+spaceToken TkSpace{} = Just Space
+spaceToken TkTab{} = Just Tab
+spaceToken (TkContinue nl _) = Just $ Continued nl []
+spaceToken _ = Nothing
+
+collapseContinue :: [Whitespace] -> [Whitespace]
+collapseContinue [] = []
+collapseContinue (Space : xs) = Space : collapseContinue xs
+collapseContinue (Tab : xs) = Tab : collapseContinue xs
+collapseContinue (Newline nl : xs) = Newline nl : collapseContinue xs
+collapseContinue (Continued nl ws : xs) = [Continued nl $ ws <> xs]
+
+newlineToken :: PyToken a -> Maybe Newline
+newlineToken (TkNewline nl _) = Just nl
+newlineToken _ = Nothing
+
+caretMaybe :: (a -> Maybe b) -> [a] -> ([b], [a])
+caretMaybe f as =
+  case as of
+    [] -> ([], [])
+    x : xs ->
+      case f x of
+        Nothing -> ([], as)
+        Just b -> first (b :) $ caretMaybe f xs
+
+breakMaybe :: (a -> Maybe b) -> [a] -> ([a], Maybe (b, [a]))
+breakMaybe f as =
+  case as of
+    [] -> ([], Nothing)
+    x : xs ->
+      case f x of
+        Just b -> ([], Just (b, xs))
+        Nothing -> first (x :) $ breakMaybe f xs
+
+logicalLines :: [PyToken a] -> [LogicalLine a]
+logicalLines [] = []
+logicalLines tks =
+  let
+    (spaces, rest) = caretMaybe spaceToken tks
+    (line, rest') = breakMaybe newlineToken rest
+  in
+    LogicalLine
+      (case tks of
+         [] -> error "couldn't generate annotation for logical line"
+         tk : _ -> pyTokenAnn tk)
+      (collapseContinue spaces)
+      line
+      (fst <$> rest')
+      :
+    logicalLines (maybe [] snd rest') 
+
+data IndentedLine a
+  = Indent a
+  | Dedent
+  | IndentedLine (LogicalLine a)
+  deriving (Eq, Show)
+
+isBlankToken :: PyToken a -> Bool
+isBlankToken TkSpace{} = True
+isBlankToken TkTab{} = True
+isBlankToken TkComment{} = True
+isBlankToken TkNewline{} = True
+isBlankToken _ = False
+
+expandTabs :: Int -> [Whitespace] -> [Whitespace]
+expandTabs size = go 0
+  where
+    go !n (Tab : xs) =
+      let
+        (q, r) = quotRem n 8
+        count = size - r
+      in
+        Space :
+        if r == 0
+        then replicate (size-1) Space <> go (n + size) xs
+        else replicate (count-1) Space <> go (n + count) xs
+    go !n (Space : xs) = Space : go (n + 1) xs
+    go !n (Newline{} : _) = error "newline in expandTabs"
+    go !n xs = xs
+
+countSpaces :: [Whitespace] -> Int
+countSpaces (Space : xs) = 1 + countSpaces xs
+countSpaces (Tab : _) = error "tab in countSpaces"
+countSpaces (Newline{} : _) = error "newline in countSpaces"
+countSpaces _ = 0
+
+data TabError = TabError deriving (Eq, Show)
+
+indentation :: [LogicalLine a] -> Either TabError [IndentedLine a]
+indentation lls =
+  flip evalStateT (pure []) $
+  (<>) <$> (concat <$> traverse go lls) <*> finalDedents
+  where
+    finalDedents :: StateT (NonEmpty [Whitespace]) (Either TabError) [IndentedLine a]
+    finalDedents = do
+      i :| is <- get
+      case is of
+        [] -> pure []
+        i' : is' -> do
+          put $ i' :| is'
+          (Dedent :) <$> finalDedents
+
+    dedents :: Int -> StateT (NonEmpty [Whitespace]) (Either TabError) [IndentedLine a]
+    dedents n = do
+      i :| is <- get
+      if countSpaces (expandTabs 8 i) < n
+        then (Dedent :) <$> dedents n
+        else pure []
+
+    go :: LogicalLine a -> StateT (NonEmpty [Whitespace]) (Either TabError) [IndentedLine a]
+    go ll@(LogicalLine ann spaces line nl) = do
+      i :| is <- get
+      let
+        et8 = countSpaces $ expandTabs 8 spaces
+        et1 = countSpaces $ expandTabs 1 spaces
+        et8i = countSpaces $ expandTabs 8 i
+        et1i = countSpaces $ expandTabs 1 i
+      when
+        (not (et8 < et8i && et1 < et1i) &&
+         not (et8 > et8i && et1 > et1i) &&
+         not (et8 == et8i && et1 == et1i))
+        (lift $ Left TabError)
+      case compare et8 et8i of
+        LT -> (<> [IndentedLine ll]) <$> dedents et8
+        EQ -> pure [IndentedLine ll]
+        GT -> do
+          modify $ NonEmpty.cons spaces
+          pure [Indent ann, IndentedLine ll]

--- a/src/Language/Python/Internal/Lexer.hs
+++ b/src/Language/Python/Internal/Lexer.hs
@@ -35,6 +35,7 @@ data QuoteType = SingleQuote | DoubleQuote
 
 data PyToken a
   = TkIf a
+  | TkElse a
   | TkDef a
   | TkReturn a
   | TkPass a
@@ -113,6 +114,7 @@ pyTokenAnn tk =
     TkPlus a -> a
     TkMinus a -> a
     TkIf a -> a
+    TkElse a -> a
     TkInt _ a -> a
     TkFloat _ _ a -> a
     TkIdent _ a -> a
@@ -218,6 +220,7 @@ parseToken =
   fmap (\(f :^ sp) -> f sp) . careted $
   asum @[]
     [ string "if" $> TkIf
+    , string "else" $> TkElse
     , string "def" $> TkDef
     , string "return" $> TkReturn
     , string "pass" $> TkPass

--- a/src/Language/Python/Internal/Lexer.hs
+++ b/src/Language/Python/Internal/Lexer.hs
@@ -66,6 +66,7 @@ data PyToken a
   | TkColon a
   | TkSemicolon a
   | TkComma a
+  | TkDot a
   | TkPlus a
   | TkMinus a
   | TkComment String Newline a
@@ -116,6 +117,7 @@ pyTokenAnn tk =
     TkColon a -> a
     TkSemicolon a -> a
     TkComma a -> a
+    TkDot a -> a
     TkComment _ _ a -> a
     TkStar a -> a
     TkDoubleStar a -> a
@@ -244,6 +246,7 @@ parseToken =
            TkShortString sp SingleQuote <$> manyTill stringChar (char '\''))
     , TkComment <$ char '#' <*> many (noneOf "\r\n") <*> parseNewline
     , char ',' $> TkComma
+    , char '.' $> TkDot
     , fmap TkIdent $
       (:) <$>
       (letter <|> char '_') <*>

--- a/src/Language/Python/Internal/Optics.hs
+++ b/src/Language/Python/Internal/Optics.hs
@@ -135,7 +135,7 @@ instance HasNewlines CompoundStatement where
 
 instance HasNewlines Statement where
   _Newlines f (CompoundStatement c) = CompoundStatement <$> _Newlines f c
-  _Newlines f (SmallStatements s ss sc nl) = SmallStatements s ss sc <$> f nl
+  _Newlines f (SmallStatements s ss sc nl) = SmallStatements s ss sc <$> traverse f nl
 
 instance HasNewlines Module where
   _Newlines = _Wrapped.traverse.failing (_Left._3) (_Right._Newlines)

--- a/src/Language/Python/Internal/Optics.hs
+++ b/src/Language/Python/Internal/Optics.hs
@@ -138,4 +138,4 @@ instance HasNewlines Statement where
   _Newlines f (SmallStatements s ss sc nl) = SmallStatements s ss sc <$> traverse f nl
 
 instance HasNewlines Module where
-  _Newlines = _Wrapped.traverse.failing (_Left._3) (_Right._Newlines)
+  _Newlines = _Wrapped.traverse.failing (_Left._3.traverse) (_Right._Newlines)

--- a/src/Language/Python/Internal/Optics.hs
+++ b/src/Language/Python/Internal/Optics.hs
@@ -96,7 +96,9 @@ _Indents
   :: Traversal'
        (Statement v a)
        [Whitespace]
-_Indents f = fmap coerce . (_Blocks._Wrapped) ((traverse._2) f . coerce)
+_Indents f =
+  fmap coerce .
+  (_Blocks._Wrapped) ((traverse._2.indentWhitespaces) f . coerce)
 
 class HasNewlines s where
   _Newlines :: Traversal' (s v a) Newline

--- a/src/Language/Python/Internal/Optics.hs
+++ b/src/Language/Python/Internal/Optics.hs
@@ -3,13 +3,16 @@
 {-# language DefaultSignatures, FlexibleContexts #-}
 module Language.Python.Internal.Optics where
 
+import Control.Lens.Fold (Fold)
 import Control.Lens.Getter (Getter, to)
+import Control.Lens.Setter ((.~))
 import Control.Lens.TH (makeLenses)
 import Control.Lens.Traversal (Traversal', failing)
-import Control.Lens.Tuple (_2, _3, _4)
+import Control.Lens.Tuple (_3, _5)
 import Control.Lens.Prism (Prism, _Right, _Left, prism)
 import Control.Lens.Wrapped (_Wrapped)
-import Data.Coerce
+import Data.Coerce (Coercible, coerce)
+import Data.Function ((&))
 import Data.List.NonEmpty
 import Language.Python.Internal.Syntax
 
@@ -50,13 +53,15 @@ _Fundef
   :: Prism
        (Statement v a)
        (Statement '[] a)
-       ( a
+       ( Indents a
+       , a
        , NonEmpty Whitespace, Ident v a
        , [Whitespace], CommaSep (Param v a)
        , [Whitespace], [Whitespace], Newline
        , Block v a
        )
-       ( a
+       ( Indents a
+       , a
        , NonEmpty Whitespace, Ident '[] a
        , [Whitespace], CommaSep (Param '[] a)
        , [Whitespace], [Whitespace], Newline
@@ -64,10 +69,10 @@ _Fundef
        )
 _Fundef =
   prism
-    (\(a, b, c, d, e, f, g, h, i) -> CompoundStatement (Fundef a b c d e f g h i))
+    (\(idnt, a, b, c, d, e, f, g, h, i) -> CompoundStatement (Fundef idnt a b c d e f g h i))
     (\case
-        (coerce -> CompoundStatement (Fundef a b c d e f g h i)) ->
-          Right (a, b, c, d, e, f, g, h, i)
+        (coerce -> CompoundStatement (Fundef idnt a b c d e f g h i)) ->
+          Right (idnt, a, b, c, d, e, f, g, h, i)
         (coerce -> a) -> Left a)
 
 _Call
@@ -92,13 +97,86 @@ _Ident =
     (\(a, b) -> Ident a b)
     (\case; (coerce -> Ident a b) -> Right (a, b); (coerce -> a) -> Left a)
 
-_Indents
-  :: Traversal'
-       (Statement v a)
-       [Whitespace]
-_Indents f =
-  fmap coerce .
-  (_Blocks._Wrapped) ((traverse._2.indentWhitespaces) f . coerce)
+_Indent :: HasIndents s => Traversal' (s '[] a) [Whitespace]
+_Indent = _Indents.indentsValue.traverse.indentWhitespaces
+
+noIndents :: HasIndents s => Fold (s '[] a) (s '[] a)
+noIndents f s = f $ s & _Indents.indentsValue .~ []
+
+class HasIndents s where
+  _Indents :: Traversal' (s '[] a) (Indents a)
+
+instance HasIndents Statement where
+  _Indents f (SmallStatements idnt a b c d) =
+    (\idnt' -> SmallStatements idnt' a b c d) <$> f idnt
+  _Indents f (CompoundStatement c) = CompoundStatement <$> _Indents f c
+
+instance HasIndents Block where
+  _Indents = _Statements._Indents
+
+instance HasIndents CompoundStatement where
+  _Indents fun s =
+    case s of
+      Fundef idnt a b c d e f g h i ->
+        (\idnt' i' -> Fundef idnt' a b c d e f g h i') <$>
+        fun idnt <*>
+        _Indents fun i
+      If idnt a b c d e f g ->
+        (\idnt' f' g' -> If idnt' a b c d e f' g') <$>
+        fun idnt <*>
+        _Indents fun f <*>
+        traverse
+          (\(idnt, a, b, c, d) ->
+             (\idnt' d' -> (idnt', a, b, c, d')) <$>
+             fun idnt <*>
+             _Indents fun d)
+          g
+      While idnt a b c d e f ->
+        (\idnt' f' -> While idnt' a b c d e f') <$>
+        fun idnt <*>
+        _Indents fun f
+      TryExcept idnt a b c d e f g h ->
+        (\idnt' e' f' g' h' -> TryExcept idnt' a b c d e' f' g' h') <$>
+        fun idnt <*>
+        _Indents fun e <*>
+        traverse
+          (\(idnt, a, b, c, d, e) ->
+             (\idnt' e' -> (idnt', a, b, c, d, e')) <$>
+             fun idnt <*>
+             _Indents fun e)
+          f <*>
+        traverse
+          (\(idnt, a, b, c, d) ->
+             (\idnt' d' -> (idnt', a, b, c, d')) <$>
+             fun idnt <*>
+             _Indents fun d)
+          g <*>
+        traverse
+          (\(idnt, a, b, c, d) ->
+             (\idnt' d' -> (idnt', a, b, c, d')) <$>
+             fun idnt <*>
+             _Indents fun d)
+          h
+      TryFinally idnt a b c d e idnt2 f g h i ->
+        (\idnt' e' idnt2' i' -> TryFinally idnt' a b c d e' idnt2' f g h i') <$>
+        fun idnt <*>
+        _Indents fun e <*>
+        fun idnt2 <*>
+        _Indents fun i
+      For idnt a b c d e f g h i ->
+        (\idnt' h' i' -> For idnt' a b c d e f g h' i') <$>
+        fun idnt <*>
+        _Indents fun h <*>
+        traverse
+          (\(idnt, a, b, c, d) ->
+             (\idnt' d' -> (idnt', a, b, c, d')) <$>
+             fun idnt <*>
+             _Indents fun d)
+          i
+      ClassDef idnt a b c d e f g ->
+        (\idnt' g' -> ClassDef idnt' a b c d e f g') <$>
+        fun idnt <*>
+        _Indents fun g
 
 class HasNewlines s where
   _Newlines :: Traversal' (s v a) Newline
@@ -106,38 +184,40 @@ class HasNewlines s where
 instance HasNewlines Block where
   _Newlines f (Block b) =
     Block <$>
-    traverse (\(a, b, c) -> (,,) a b <$> (_Right._Newlines) f c) b
+    (traverse._Right._Newlines) f b
 
 instance HasNewlines CompoundStatement where
   _Newlines fun s =
     case s of
-      Fundef ann ws1 name ws2 params ws3 ws4 nl block ->
-        Fundef ann ws1 name ws2 params ws3 ws4 <$> fun nl <*> _Newlines fun block
-      If ann ws1 cond ws3 nl block els ->
-        If ann ws1 cond ws3 <$>
+      Fundef idnt ann ws1 name ws2 params ws3 ws4 nl block ->
+        Fundef idnt ann ws1 name ws2 params ws3 ws4 <$> fun nl <*> _Newlines fun block
+      If idnt ann ws1 cond ws3 nl block els ->
+        If idnt ann ws1 cond ws3 <$>
         fun nl <*>
         _Newlines fun block <*>
         traverse
-          (\(a, b, c, d) -> (,,,) a b <$> fun nl <*> _Newlines fun block)
+          (\(idnt, a, b, c, d) -> (,,,,) idnt a b <$> fun nl <*> _Newlines fun block)
           els
-      While ann ws1 cond ws3 nl block ->
-        While ann ws1 cond ws3 <$> fun nl <*> _Newlines fun block
-      TryExcept a b c d e f k l ->
-        TryExcept a b c <$> fun d <*> _Newlines fun e <*>
-        traverse (\(x, y, z, w, w') -> (,,,,) x y z <$> fun w <*> _Newlines fun w') f <*>
-        traverse (\(x, y, z, w) -> (,,,) x y <$> fun z <*> _Newlines fun w) k <*>
-        traverse (\(x, y, z, w) -> (,,,) x y <$> fun z <*> _Newlines fun w) l
-      TryFinally a b c d e f g h i ->
-        TryFinally a b c <$> fun d <*> _Newlines fun e <*>
+      While idnt ann ws1 cond ws3 nl block ->
+        While idnt ann ws1 cond ws3 <$> fun nl <*> _Newlines fun block
+      TryExcept idnt a b c d e f k l ->
+        TryExcept idnt a b c <$> fun d <*> _Newlines fun e <*>
+        traverse (\(idnt, x, y, z, w, w') -> (,,,,,) idnt x y z <$> fun w <*> _Newlines fun w') f <*>
+        traverse (\(idnt, x, y, z, w) -> (,,,,) idnt x y <$> fun z <*> _Newlines fun w) k <*>
+        traverse (\(idnt, x, y, z, w) -> (,,,,) idnt x y <$> fun z <*> _Newlines fun w) l
+      TryFinally idnt a b c d e idnt2 f g h i ->
+        TryFinally idnt a b c <$> fun d <*> _Newlines fun e <*> pure idnt2 <*>
         pure f <*> pure g <*> fun h <*> _Newlines fun i
-      For a b c d e f g h i ->
-        For a b c d e f <$> fun g <*> _Newlines fun h <*> (traverse._4._Newlines) fun i
-      ClassDef a b c d e f g ->
-        ClassDef a b (coerce c) (coerce d) e <$> fun f <*> _Newlines fun g
+      For idnt a b c d e f g h i ->
+        For idnt a b c d e f <$> fun g <*> _Newlines fun h <*> (traverse._5._Newlines) fun i
+      ClassDef idnt a b c d e f g ->
+        ClassDef idnt a b (coerce c) (coerce d) e <$> fun f <*> _Newlines fun g
 
 instance HasNewlines Statement where
-  _Newlines f (CompoundStatement c) = CompoundStatement <$> _Newlines f c
-  _Newlines f (SmallStatements s ss sc nl) = SmallStatements s ss sc <$> traverse f nl
+  _Newlines f (CompoundStatement c) =
+    CompoundStatement <$> _Newlines f c
+  _Newlines f (SmallStatements idnts s ss sc nl) =
+    SmallStatements idnts s ss sc <$> traverse f nl
 
 instance HasNewlines Module where
   _Newlines = _Wrapped.traverse.failing (_Left._3.traverse) (_Right._Newlines)

--- a/src/Language/Python/Internal/Parse.hs
+++ b/src/Language/Python/Internal/Parse.hs
@@ -593,7 +593,8 @@ arg =
 compoundStatement :: Parser ann (CompoundStatement '[] ann)
 compoundStatement =
   fundef <!>
-  ifSt
+  ifSt <!>
+  whileSt
   where
     fundef =
       (\(tkDef, defSpaces) -> Fundef (pyTokenAnn tkDef) (NonEmpty.fromList defSpaces)) <$>
@@ -620,6 +621,13 @@ compoundStatement =
          (snd <$> colon space) <*>
          eol <*
          indent <*> block <* dedent)
+
+    whileSt =
+      (\(tk, s) -> While (pyTokenAnn tk) s) <$>
+      token space (TkWhile ()) <*>
+      expr space <*>
+      (snd <$> colon space) <*>
+      eol <* indent <*> block <* dedent
 
 module_ :: Parser ann (Module '[] ann)
 module_ =

--- a/src/Language/Python/Internal/Parse.hs
+++ b/src/Language/Python/Internal/Parse.hs
@@ -1,25 +1,319 @@
 {-# language DataKinds #-}
 {-# language FlexibleContexts #-}
 {-# language LambdaCase #-}
+{-# language GeneralizedNewtypeDeriving #-}
 module Language.Python.Internal.Parse where
 
-import Control.Applicative ((<|>), liftA2)
+import Control.Applicative ((<|>), liftA2, many, some, optional)
 import Control.Lens.Getter ((^.))
+import Control.Monad (replicateM, unless)
+import Control.Monad.Except (ExceptT(..), runExceptT, throwError)
 import Control.Monad.State
+  (MonadState, StateT(..), get, put, modify, evalStateT, runStateT)
+import Control.Monad.Writer.Strict (Writer, runWriter, writer, tell)
 import Data.Char (chr, isAscii)
 import Data.Foldable
 import Data.Function ((&))
 import Data.Functor
+import Data.Functor.Alt (Alt((<!>)))
+import qualified Data.Functor.Alt as Alt (many, optional)
+import Data.Functor.Classes (liftEq)
 import Data.List.NonEmpty (NonEmpty(..), some1)
 import Data.Semigroup hiding (Arg)
-import Text.Parser.Token hiding (commaSep, commaSep1, dot)
-import Text.Trifecta hiding (newline, commaSep, commaSep1, dot)
+import Text.Parser.Token (Unspaced(..), TokenParsing, ident)
+import Text.Trifecta
+  ( (<?>), CharParsing, DeltaParsing, Span, Spanned(..), eof, try, noneOf, char
+  , string, manyTill, spanned, notFollowedBy, chainl1, digit, unexpected, oneOf
+  , satisfy
+  )
 
 import qualified Data.List.NonEmpty as NonEmpty
 
+import Language.Python.Internal.Lexer
 import Language.Python.Internal.Syntax
 
 type Untagged s a = a -> s '[] a
+
+data ParseError ann
+  = UnexpectedEndOfInput
+  | UnexpectedEndOfLine
+  | UnexpectedEndOfBlock
+  | UnexpectedIndent
+  | ExpectedIndent
+  | ExpectedEndOfBlock
+  | ExpectedIdentifier { peGot :: PyToken ann }
+  | ExpectedString { peGot :: PyToken ann }
+  | ExpectedInteger { peGot :: PyToken ann }
+  | ExpectedComment { peGot :: PyToken ann }
+  | ExpectedToken { peExpected :: PyToken (), peGot :: PyToken ann }
+  | ExpectedEndOfLine { peGotTokens :: [PyToken ann] }
+  | ExpectedEndOfInput { peGotCtxt :: [Either (Nested ann) (LogicalLine ann)] }
+  deriving (Eq, Show)
+
+newtype Consumed = Consumed { unConsumed :: Bool }
+  deriving (Eq, Show)
+
+instance Monoid Consumed where
+  mempty = Consumed False
+  Consumed a `mappend` Consumed b = Consumed $! a || b
+
+newtype Parser' ann a
+  = Parser'
+  { unParser
+      :: StateT
+           [[Either (Nested ann) (LogicalLine ann)]]
+           (ExceptT (ParseError ann) (Writer Consumed))
+           a
+  } deriving (Functor, Applicative, Monad)
+
+instance Alt (Parser' ann) where
+  Parser' pa <!> Parser' pb =
+    Parser' $ do
+      st <- get
+      let (res, Consumed b) = runWriter . runExceptT $ runStateT pa st
+      if b
+        then StateT $ \_ -> ExceptT (writer (res, Consumed b))
+        else case res of
+          Left{} -> pb
+          Right (a, st') -> put st' $> a
+
+runParser :: Parser' ann a -> Nested ann -> Either (ParseError ann) a
+runParser (Parser' p) =
+  fst . runWriter .
+  runExceptT .
+  evalStateT p .
+  pure . toList . unNested
+
+currentToken :: Parser' ann (PyToken ann)
+currentToken = Parser' $ do
+  ctxt <- get
+  case ctxt of
+    [] -> throwError UnexpectedEndOfInput
+    current : rest ->
+      case current of
+        [] -> throwError UnexpectedEndOfBlock
+        Right ll@(LogicalLine _ _ _ tks nl) : rest' ->
+          case tks of
+            [] -> throwError UnexpectedEndOfLine
+            [tk] | Nothing <- nl -> do
+              put $ case rest' of
+                [] -> rest
+                _ -> rest' : rest
+              pure tk
+            tk : rest'' ->
+              put ((Right (ll { llLine = rest'' }) : rest') : rest) $> tk
+        Left _ : _ -> throwError UnexpectedIndent
+
+eol :: Parser' ann Newline
+eol = Parser' $ do
+  ctxt <- get
+  case ctxt of
+    [] -> throwError UnexpectedEndOfInput
+    current : rest ->
+      case current of
+        [] -> throwError UnexpectedEndOfBlock
+        Left _ : _ -> throwError UnexpectedIndent
+        Right ll@(LogicalLine _ _ _ tks nl) : rest' ->
+          case tks of
+            _ : _ -> throwError $ ExpectedEndOfLine tks
+            [] ->
+              case nl of
+                Nothing -> throwError $ ExpectedEndOfLine tks
+                Just (_, nl') -> do
+                  put (rest' : rest)
+                  tell (Consumed True) $> nl'
+
+eof' :: Parser' ann ()
+eof' = Parser' $ do
+  ctxt <- get
+  case ctxt of
+    [] -> tell $ Consumed True
+    current : _ -> throwError $ ExpectedEndOfInput current
+
+indent' :: Parser' ann ()
+indent' = Parser' $ do
+  ctxt <- get
+  case ctxt of
+    [] -> throwError UnexpectedEndOfInput
+    current : rest ->
+      case current of
+        [] -> throwError UnexpectedEndOfBlock
+        Right _ : _ -> throwError ExpectedIndent
+        Left inner : rest' -> do
+          put $ toList (unNested inner) : (case rest' of; [] -> rest; _ -> rest' : rest)
+          tell $ Consumed True
+
+dedent' :: Parser' ann ()
+dedent' = Parser' $ do
+  ctxt <- get
+  case ctxt of
+    [] -> pure ()
+    current : rest ->
+      case current of
+        [] -> put rest *> tell (Consumed True)
+        _ -> throwError ExpectedEndOfBlock
+
+space :: Parser' ann Whitespace
+space =
+  Space <$ token (TkSpace ()) <!>
+  Tab <$ token (TkTab ())
+
+parseError :: ParseError ann -> Parser' ann a
+parseError pe = Parser' $ throwError pe
+
+token :: PyToken b -> Parser' ann (PyToken ann, [Whitespace])
+token tk = do
+  curTk <- currentToken
+  unless (liftEq (\_ _ -> True) tk curTk) .
+    parseError $ ExpectedToken (() <$ tk) curTk
+  Parser' (tell $ Consumed True)
+  (,) curTk <$> Alt.many space
+
+identifier' :: Parser' ann (Ident '[] ann)
+identifier' = do
+  curTk <- currentToken
+  case curTk of
+    TkIdent n ann -> do
+      Parser' (tell $ Consumed True)
+      MkIdent ann n <$> Alt.many space
+    _ -> Parser' . throwError $ ExpectedIdentifier curTk
+
+integer' :: Parser' ann (Expr '[] ann)
+integer' = do
+  curTk <- currentToken
+  case curTk of
+    TkInt n ann -> do
+      Parser' (tell $ Consumed True)
+      Int ann n <$> Alt.many space
+    _ -> Parser' . throwError $ ExpectedInteger curTk
+
+string' :: Parser' ann (Expr '[] ann)
+string' = do
+  curTk <- currentToken
+  (case curTk of
+    TkShortString qt val ann ->
+      Parser' (tell $ Consumed True) $>
+      String ann Nothing
+      (case qt of
+         SingleQuote -> ShortSingle
+         DoubleQuote -> ShortDouble)
+      val
+    TkLongString qt val ann ->
+      Parser' (tell $ Consumed True) $>
+      String ann Nothing
+      (case qt of
+         SingleQuote -> LongSingle
+         DoubleQuote -> LongDouble)
+      val
+    _ -> Parser' . throwError $ ExpectedString curTk) <*>
+    Alt.many space
+
+between' :: Parser' ann left -> Parser' ann right -> Parser' ann a -> Parser' ann a
+between' left right pa = left *> pa <* right
+
+indents :: Parser' ann ([Whitespace], ann)
+indents = Parser' $ do
+  ctxt <- get
+  case ctxt of
+    [] -> throwError UnexpectedEndOfInput
+    current : rest ->
+      case current of
+        [] -> throwError UnexpectedEndOfBlock
+        Right ll@(LogicalLine a _ is _ _) : rest' -> pure (is, a)
+        Left _ : _ -> throwError UnexpectedIndent
+
+expr' :: Parser' ann (Expr '[] ann)
+expr' =
+  binOp plusOp
+  where
+    plusOp :: Parser' ann (BinOp ann)
+    plusOp = do
+      (tk, ws) <- token (TkPlus ())
+      pure $ Plus (pyTokenAnn tk) ws
+
+    binOp :: Parser' ann (BinOp ann) -> Parser' ann (Expr '[] ann)
+    binOp op = do
+      (t, ts) <- (,) <$> term <*> Alt.many ((,) <$> op <*> term)
+      pure $ case ts of
+        [] -> t
+        _ -> foldl (\tm (o, val) -> BinOp (tm ^. exprAnnotation) tm o val) t ts
+
+    term = factor
+
+    factor = power
+
+    power = atomExpr
+
+    atomExpr = atom
+
+    atom =
+      integer' <!>
+      string' <!>
+      (\a -> Ident (_identAnnotation a) a) <$> identifier'
+
+smallStatement' :: Parser' ann (SmallStatement '[] ann)
+smallStatement' =
+  returnSt
+  where
+    returnSt = do
+      (tkReturn, retSpaces) <- token $ TkReturn ()
+      Return (pyTokenAnn tkReturn) retSpaces <$> expr'
+
+statement' :: Parser' ann (Statement '[] ann)
+statement' =
+  SmallStatements <$>
+  smallStatement' <*>
+  Alt.many ((,) <$> fmap snd (token $ TkSemicolon ()) <*> smallStatement') <*>
+  Alt.optional (snd <$> token (TkSemicolon ())) <*>
+  (Just <$> eol <!> Nothing <$ eof')
+
+  <!>
+
+  CompoundStatement <$> compoundStatement'
+
+comment' :: Parser' ann (Comment, Newline)
+comment' = do
+  curTk <- currentToken
+  case curTk of
+    TkComment str nl _ -> Parser' (tell $ Consumed True) $> (Comment str, nl)
+    _ -> Parser' . throwError $ ExpectedComment curTk
+
+block' :: Parser' ann (Block '[] ann)
+block' = fmap Block $ (:|) <$> line <*> Alt.many line
+  where
+    commentOrEmpty = do
+      cmt <- Alt.optional comment'
+      case cmt of
+        Nothing -> (,) Nothing <$> eol
+        Just (cmt', nl) -> pure (Just cmt', nl)
+
+    line = do
+      (ws, a) <- indents
+      (,,) a ws <$>
+        (Left <$> commentOrEmpty <!>
+         Right <$> statement')
+
+compoundStatement' :: Parser' ann (CompoundStatement '[] ann)
+compoundStatement' = fundef
+  where
+    fundef = do
+      (tkDef, defSpaces) <- token $ TkDef ()
+      fnName <- identifier'
+      (_, lpSpaces) <- token $ TkLeftParen ()
+      pure () -- stuff here
+      (_, rpSpaces) <- token $ TkRightParen ()
+      (_, colonSpaces) <- token $ TkColon ()
+      nl <- eol
+      indent'
+      bl <- block'
+      dedent'
+      pure $
+        Fundef (pyTokenAnn tkDef)
+          (NonEmpty.fromList defSpaces) fnName
+          lpSpaces CommaSepNone rpSpaces
+          colonSpaces
+          nl
+          bl
 
 stringChar :: (CharParsing m, Monad m) => m Char
 stringChar = (char '\\' *> (escapeChar <|> hexChar)) <|> other
@@ -568,7 +862,7 @@ statement =
          many whitespace <*>
          smallStatement) <*>
       optional (char ';' *> many whitespace) <*>
-      newline
+      (Just <$> newline <|> Nothing <$ eof)
 
 comment :: DeltaParsing m => m Comment
 comment = (Comment <$ char '#' <*> many (noneOf "\n\r")) <?> "comment"

--- a/src/Language/Python/Internal/Parse.hs
+++ b/src/Language/Python/Internal/Parse.hs
@@ -4,6 +4,7 @@
 {-# language GeneralizedNewtypeDeriving #-}
 module Language.Python.Internal.Parse where
 
+import Control.Lens.Fold (foldOf, folded)
 import Control.Lens.Getter ((^.))
 import Control.Monad (unless)
 import Control.Monad.Except (ExceptT(..), runExceptT, throwError)
@@ -527,7 +528,7 @@ suite = do
        some1 line) <*
     dedent
   where
-    commentOrEmpty = (,,) <$> indents <*> optional comment <*> eol
+    commentOrEmpty = (,,) <$> (foldOf (indentsValue.folded.indentWhitespaces) <$> indents) <*> optional comment <*> eol
 
     commentOrIndent = many (Left <$> commentOrEmpty) <* indent
 

--- a/src/Language/Python/Internal/Parse.hs
+++ b/src/Language/Python/Internal/Parse.hs
@@ -307,7 +307,6 @@ expr ws = orTest
     arithOp =
       (\(tk, ws) -> Plus (pyTokenAnn tk) ws) <$> token ws (TkPlus ()) <!>
       (\(tk, ws) -> Minus (pyTokenAnn tk) ws) <$> token ws (TkMinus ())
-
     arithExpr = binOp arithOp term
 
     termOp =
@@ -630,7 +629,8 @@ compoundStatement =
   ifSt <!>
   whileSt <!>
   trySt <!>
-  classSt
+  classSt <!>
+  forSt
   where
     fundef =
       (\(tkDef, defSpaces) -> Fundef (pyTokenAnn tkDef) (NonEmpty.fromList defSpaces)) <$>
@@ -702,6 +702,18 @@ compoundStatement =
          optional (commaSep1 anySpace arg) <*>
          (snd <$> token space (TkRightParen ()))) <*>
       (snd <$> colon space) `thenSuite` ()
+
+    forSt =
+      (\(tk, s) -> For (pyTokenAnn tk) s) <$>
+      token space (TkFor ()) <*>
+      exprList space <*>
+      (snd <$> token space (TkIn ())) <*>
+      exprList space <*>
+      (snd <$> colon space) `withSuite`
+      optional
+        ((,,,) <$>
+         (snd <$> token space (TkElse ())) <*>
+         (snd <$> colon space) `thenSuite` ())
 
 module_ :: Parser ann (Module '[] ann)
 module_ =

--- a/src/Language/Python/Internal/Parse.hs
+++ b/src/Language/Python/Internal/Parse.hs
@@ -591,7 +591,9 @@ arg =
   expr anySpace
 
 compoundStatement :: Parser ann (CompoundStatement '[] ann)
-compoundStatement = fundef
+compoundStatement =
+  fundef <!>
+  ifSt
   where
     fundef =
       (\(tkDef, defSpaces) -> Fundef (pyTokenAnn tkDef) (NonEmpty.fromList defSpaces)) <$>
@@ -605,6 +607,19 @@ compoundStatement = fundef
       indent <*>
       block <*
       dedent
+
+    ifSt =
+      (\(tk, s) -> If (pyTokenAnn tk) s) <$>
+      token space (TkIf ()) <*>
+      expr space <*>
+      (snd <$> colon space) <*>
+      eol <* indent <*> block <* dedent <*>
+      optional
+        ((,,,) <$>
+         (snd <$> token space (TkElse ())) <*>
+         (snd <$> colon space) <*>
+         eol <*
+         indent <*> block <* dedent)
 
 module_ :: Parser ann (Module '[] ann)
 module_ =

--- a/src/Language/Python/Internal/Parse.hs
+++ b/src/Language/Python/Internal/Parse.hs
@@ -70,11 +70,6 @@ stringChar = (char '\\' *> (escapeChar <|> hexChar)) <|> other
       in
         snd $! foldr (\a (sz, val) -> (sz-1, hexDigitInt a * 16 ^ sz + val)) (size, 0) str
 
-newline :: CharParsing m => m Newline
-newline =
-  char '\n' $> LF <|>
-  char '\r' *> (char '\n' $> CRLF <|> pure CR)
-
 annotated :: DeltaParsing m => m (Span -> b) -> m b
 annotated m = (\(f :~ sp) -> f sp) <$> spanned m
 

--- a/src/Language/Python/Internal/Parse.hs
+++ b/src/Language/Python/Internal/Parse.hs
@@ -4,35 +4,22 @@
 {-# language GeneralizedNewtypeDeriving #-}
 module Language.Python.Internal.Parse where
 
-import Control.Applicative ((<|>), liftA2, many, some, optional)
 import Control.Lens.Getter ((^.))
-import Control.Monad (replicateM, unless)
+import Control.Monad (unless)
 import Control.Monad.Except (ExceptT(..), runExceptT, throwError)
 import Control.Monad.State
-  (MonadState, StateT(..), get, put, modify, evalStateT, runStateT)
+  (StateT(..), get, put, evalStateT, runStateT)
 import Control.Monad.Writer.Strict (Writer, runWriter, writer, tell)
-import Data.Char (chr, isAscii)
-import Data.Foldable
-import Data.Function ((&))
-import Data.Functor
-import Data.Functor.Alt (Alt((<!>)))
-import qualified Data.Functor.Alt as Alt (many, optional)
+import Data.Foldable (toList)
+import Data.Functor (($>))
+import Data.Functor.Alt (Alt((<!>)), many, optional)
 import Data.Functor.Classes (liftEq)
-import Data.List.NonEmpty (NonEmpty(..), some1)
-import Data.Semigroup hiding (Arg)
-import Text.Parser.Token (Unspaced(..), TokenParsing, ident)
-import Text.Trifecta
-  ( (<?>), CharParsing, DeltaParsing, Span, Spanned(..), eof, try, noneOf, char
-  , string, manyTill, spanned, notFollowedBy, chainl1, digit, unexpected, oneOf
-  , satisfy
-  )
+import Data.List.NonEmpty (NonEmpty(..))
 
 import qualified Data.List.NonEmpty as NonEmpty
 
 import Language.Python.Internal.Lexer
 import Language.Python.Internal.Syntax
-
-type Untagged s a = a -> s '[] a
 
 data ParseError ann
   = UnexpectedEndOfInput
@@ -57,8 +44,8 @@ instance Monoid Consumed where
   mempty = Consumed False
   Consumed a `mappend` Consumed b = Consumed $! a || b
 
-newtype Parser' ann a
-  = Parser'
+newtype Parser ann a
+  = Parser
   { unParser
       :: StateT
            [[Either (Nested ann) (LogicalLine ann)]]
@@ -66,9 +53,9 @@ newtype Parser' ann a
            a
   } deriving (Functor, Applicative, Monad)
 
-instance Alt (Parser' ann) where
-  Parser' pa <!> Parser' pb =
-    Parser' $ do
+instance Alt (Parser ann) where
+  Parser pa <!> Parser pb =
+    Parser $ do
       st <- get
       let (res, Consumed b) = runWriter . runExceptT $ runStateT pa st
       if b
@@ -77,15 +64,15 @@ instance Alt (Parser' ann) where
           Left{} -> pb
           Right (a, st') -> put st' $> a
 
-runParser :: Parser' ann a -> Nested ann -> Either (ParseError ann) a
-runParser (Parser' p) =
+runParser :: Parser ann a -> Nested ann -> Either (ParseError ann) a
+runParser (Parser p) =
   fst . runWriter .
   runExceptT .
   evalStateT p .
   pure . toList . unNested
 
-currentToken :: Parser' ann (PyToken ann)
-currentToken = Parser' $ do
+currentToken :: Parser ann (PyToken ann)
+currentToken = Parser $ do
   ctxt <- get
   case ctxt of
     [] -> throwError UnexpectedEndOfInput
@@ -104,8 +91,8 @@ currentToken = Parser' $ do
               put ((Right (ll { llLine = rest'' }) : rest') : rest) $> tk
         Left _ : _ -> throwError UnexpectedIndent
 
-eol :: Parser' ann Newline
-eol = Parser' $ do
+eol :: Parser ann Newline
+eol = Parser $ do
   ctxt <- get
   case ctxt of
     [] -> throwError UnexpectedEndOfInput
@@ -123,15 +110,15 @@ eol = Parser' $ do
                   put (rest' : rest)
                   tell (Consumed True) $> nl'
 
-eof' :: Parser' ann ()
-eof' = Parser' $ do
+eof :: Parser ann ()
+eof = Parser $ do
   ctxt <- get
   case ctxt of
     [] -> tell $ Consumed True
     current : _ -> throwError $ ExpectedEndOfInput current
 
-indent' :: Parser' ann ()
-indent' = Parser' $ do
+indent :: Parser ann ()
+indent = Parser $ do
   ctxt <- get
   case ctxt of
     [] -> throwError UnexpectedEndOfInput
@@ -143,8 +130,8 @@ indent' = Parser' $ do
           put $ toList (unNested inner) : (case rest' of; [] -> rest; _ -> rest' : rest)
           tell $ Consumed True
 
-dedent' :: Parser' ann ()
-dedent' = Parser' $ do
+dedent :: Parser ann ()
+dedent = Parser $ do
   ctxt <- get
   case ctxt of
     [] -> pure ()
@@ -153,66 +140,66 @@ dedent' = Parser' $ do
         [] -> put rest *> tell (Consumed True)
         _ -> throwError ExpectedEndOfBlock
 
-space :: Parser' ann Whitespace
+space :: Parser ann Whitespace
 space =
   Space <$ token (TkSpace ()) <!>
   Tab <$ token (TkTab ())
 
-parseError :: ParseError ann -> Parser' ann a
-parseError pe = Parser' $ throwError pe
+parseError :: ParseError ann -> Parser ann a
+parseError pe = Parser $ throwError pe
 
-token :: PyToken b -> Parser' ann (PyToken ann, [Whitespace])
+token :: PyToken b -> Parser ann (PyToken ann, [Whitespace])
 token tk = do
   curTk <- currentToken
   unless (liftEq (\_ _ -> True) tk curTk) .
     parseError $ ExpectedToken (() <$ tk) curTk
-  Parser' (tell $ Consumed True)
-  (,) curTk <$> Alt.many space
+  Parser (tell $ Consumed True)
+  (,) curTk <$> many space
 
-identifier' :: Parser' ann (Ident '[] ann)
-identifier' = do
+identifier :: Parser ann (Ident '[] ann)
+identifier = do
   curTk <- currentToken
   case curTk of
     TkIdent n ann -> do
-      Parser' (tell $ Consumed True)
-      MkIdent ann n <$> Alt.many space
-    _ -> Parser' . throwError $ ExpectedIdentifier curTk
+      Parser (tell $ Consumed True)
+      MkIdent ann n <$> many space
+    _ -> Parser . throwError $ ExpectedIdentifier curTk
 
-integer' :: Parser' ann (Expr '[] ann)
-integer' = do
+integer :: Parser ann (Expr '[] ann)
+integer = do
   curTk <- currentToken
   case curTk of
     TkInt n ann -> do
-      Parser' (tell $ Consumed True)
-      Int ann n <$> Alt.many space
-    _ -> Parser' . throwError $ ExpectedInteger curTk
+      Parser (tell $ Consumed True)
+      Int ann n <$> many space
+    _ -> Parser . throwError $ ExpectedInteger curTk
 
-string' :: Parser' ann (Expr '[] ann)
-string' = do
+string :: Parser ann (Expr '[] ann)
+string = do
   curTk <- currentToken
   (case curTk of
-    TkShortString qt val ann ->
-      Parser' (tell $ Consumed True) $>
-      String ann Nothing
+    TkShortString sp qt val ann ->
+      Parser (tell $ Consumed True) $>
+      String ann sp
       (case qt of
          SingleQuote -> ShortSingle
          DoubleQuote -> ShortDouble)
       val
-    TkLongString qt val ann ->
-      Parser' (tell $ Consumed True) $>
-      String ann Nothing
+    TkLongString sp qt val ann ->
+      Parser (tell $ Consumed True) $>
+      String ann sp
       (case qt of
          SingleQuote -> LongSingle
          DoubleQuote -> LongDouble)
       val
-    _ -> Parser' . throwError $ ExpectedString curTk) <*>
-    Alt.many space
+    _ -> Parser . throwError $ ExpectedString curTk) <*>
+    many space
 
-between' :: Parser' ann left -> Parser' ann right -> Parser' ann a -> Parser' ann a
-between' left right pa = left *> pa <* right
+between :: Parser ann left -> Parser ann right -> Parser ann a -> Parser ann a
+between left right pa = left *> pa <* right
 
-indents :: Parser' ann ([Whitespace], ann)
-indents = Parser' $ do
+indents :: Parser ann ([Whitespace], ann)
+indents = Parser $ do
   ctxt <- get
   case ctxt of
     [] -> throwError UnexpectedEndOfInput
@@ -222,21 +209,21 @@ indents = Parser' $ do
         Right ll@(LogicalLine a _ is _ _) : rest' -> pure (is, a)
         Left _ : _ -> throwError UnexpectedIndent
 
-expr' :: Parser' ann (Expr '[] ann)
-expr' =
+expr :: Parser ann (Expr '[] ann)
+expr =
   binOp plusOp
   where
-    plusOp :: Parser' ann (BinOp ann)
-    plusOp = do
-      (tk, ws) <- token (TkPlus ())
-      pure $ Plus (pyTokenAnn tk) ws
+    plusOp :: Parser ann (BinOp ann)
+    plusOp = (\(tk, ws) -> Plus (pyTokenAnn tk) ws) <$> token (TkPlus ())
 
-    binOp :: Parser' ann (BinOp ann) -> Parser' ann (Expr '[] ann)
-    binOp op = do
-      (t, ts) <- (,) <$> term <*> Alt.many ((,) <$> op <*> term)
-      pure $ case ts of
-        [] -> t
-        _ -> foldl (\tm (o, val) -> BinOp (tm ^. exprAnnotation) tm o val) t ts
+    binOp :: Parser ann (BinOp ann) -> Parser ann (Expr '[] ann)
+    binOp op =
+      (\t ts ->
+          case ts of
+            [] -> t
+            _ -> foldl (\tm (o, val) -> BinOp (tm ^. exprAnnotation) tm o val) t ts) <$>
+     term <*>
+     many ((,) <$> op <*> term)
 
     term = factor
 
@@ -247,630 +234,110 @@ expr' =
     atomExpr = atom
 
     atom =
-      integer' <!>
-      string' <!>
-      (\a -> Ident (_identAnnotation a) a) <$> identifier'
+      integer <!>
+      string <!>
+      (\a -> Ident (_identAnnotation a) a) <$> identifier
 
-smallStatement' :: Parser' ann (SmallStatement '[] ann)
-smallStatement' =
+smallStatement :: Parser ann (SmallStatement '[] ann)
+smallStatement =
   returnSt
   where
-    returnSt = do
-      (tkReturn, retSpaces) <- token $ TkReturn ()
-      Return (pyTokenAnn tkReturn) retSpaces <$> expr'
+    returnSt =
+      (\(tkReturn, retSpaces) -> Return (pyTokenAnn tkReturn) retSpaces) <$>
+      token (TkReturn ()) <*>
+      expr
 
-statement' :: Parser' ann (Statement '[] ann)
-statement' =
+statement :: Parser ann (Statement '[] ann)
+statement =
   SmallStatements <$>
-  smallStatement' <*>
-  Alt.many ((,) <$> fmap snd (token $ TkSemicolon ()) <*> smallStatement') <*>
-  Alt.optional (snd <$> token (TkSemicolon ())) <*>
-  (Just <$> eol <!> Nothing <$ eof')
+  smallStatement <*>
+  many ((,) <$> fmap snd (token $ TkSemicolon ()) <*> smallStatement) <*>
+  optional (snd <$> token (TkSemicolon ())) <*>
+  (Just <$> eol <!> Nothing <$ eof)
 
   <!>
 
-  CompoundStatement <$> compoundStatement'
+  CompoundStatement <$> compoundStatement
 
-comment' :: Parser' ann (Comment, Newline)
-comment' = do
+comment :: Parser ann (Comment, Newline)
+comment = do
   curTk <- currentToken
   case curTk of
-    TkComment str nl _ -> Parser' (tell $ Consumed True) $> (Comment str, nl)
-    _ -> Parser' . throwError $ ExpectedComment curTk
+    TkComment str nl _ -> Parser (tell $ Consumed True) $> (Comment str, nl)
+    _ -> Parser . throwError $ ExpectedComment curTk
 
-block' :: Parser' ann (Block '[] ann)
-block' = fmap Block $ (:|) <$> line <*> Alt.many line
+block :: Parser ann (Block '[] ann)
+block = fmap Block $ (:|) <$> line <*> many line
   where
     commentOrEmpty = do
-      cmt <- Alt.optional comment'
+      cmt <- optional comment
       case cmt of
         Nothing -> (,) Nothing <$> eol
         Just (cmt', nl) -> pure (Just cmt', nl)
 
     line = do
       (ws, a) <- indents
-      (,,) a ws <$>
-        (Left <$> commentOrEmpty <!>
-         Right <$> statement')
+      fmap ((,,) a ws) $
+        Left <$> commentOrEmpty <!>
+        Right <$> statement
 
-compoundStatement' :: Parser' ann (CompoundStatement '[] ann)
-compoundStatement' = fundef
+comma :: Parser ann (PyToken ann, [Whitespace])
+comma = token $ TkComma ()
+
+commaSep :: Parser ann a -> Parser ann (CommaSep a)
+commaSep pa =
+  (\a -> maybe (CommaSepOne a) (uncurry $ CommaSepMany a)) <$>
+  pa <*>
+  optional ((,) <$> (snd <$> comma) <*> commaSep pa)
+
+  <!>
+
+  pure CommaSepNone
+
+param :: Parser ann (Param '[] ann)
+param =
+  (\a ->
+     maybe
+       (PositionalParam (_identAnnotation a) a)
+       (uncurry $ KeywordParam (_identAnnotation a) a)) <$>
+  identifier <*>
+  optional ((,) <$> (snd <$> token (TkEq ())) <*> expr)
+
+  <!>
+
+  (\(a, b) -> StarParam (pyTokenAnn a) b) <$> token (TkStar ()) <*> identifier
+
+  <!>
+
+  (\(a, b) -> DoubleStarParam (pyTokenAnn a) b) <$> token (TkDoubleStar ()) <*> identifier
+
+compoundStatement :: Parser ann (CompoundStatement '[] ann)
+compoundStatement = fundef
   where
-    fundef = do
-      (tkDef, defSpaces) <- token $ TkDef ()
-      fnName <- identifier'
-      (_, lpSpaces) <- token $ TkLeftParen ()
-      pure () -- stuff here
-      (_, rpSpaces) <- token $ TkRightParen ()
-      (_, colonSpaces) <- token $ TkColon ()
-      nl <- eol
-      indent'
-      bl <- block'
-      dedent'
-      pure $
-        Fundef (pyTokenAnn tkDef)
-          (NonEmpty.fromList defSpaces) fnName
-          lpSpaces CommaSepNone rpSpaces
-          colonSpaces
-          nl
-          bl
-
-stringChar :: (CharParsing m, Monad m) => m Char
-stringChar = (char '\\' *> (escapeChar <|> hexChar)) <|> other
-  where
-    other = satisfy isAscii
-    escapeChar =
-      asum
-      [ char '\\'
-      , char '\''
-      , char '"'
-      , char 'a' $> '\a'
-      , char 'b' $> '\b'
-      , char 'f' $> '\f'
-      , char 'n' $> '\n'
-      , char 'r' $> '\r'
-      , char 't' $> '\t'
-      , char 'v' $> '\v'
-      ]
-
-    hexChar =
-      char 'U' *>
-      (hexToInt <$> replicateM 8 (oneOf "0123456789ABCDEF") >>=
-       \a -> if a <= 0x10FFFF then pure (chr a) else unexpected "value outside unicode range")
-
-    hexDigitInt c =
-      case c of
-        '0' -> 0
-        '1' -> 1
-        '2' -> 2
-        '3' -> 3
-        '4' -> 4
-        '5' -> 5
-        '6' -> 6
-        '7' -> 7
-        '8' -> 8
-        '9' -> 9
-        'A' -> 10
-        'B' -> 11
-        'C' -> 12
-        'D' -> 13
-        'E' -> 14
-        'F' -> 15
-        _ -> error "impossible"
-
-    hexToInt str =
-      let
-        size = length str
-      in
-        snd $! foldr (\a (sz, val) -> (sz-1, hexDigitInt a * 16 ^ sz + val)) (size, 0) str
-
-annotated :: DeltaParsing m => m (Span -> b) -> m b
-annotated m = (\(f :~ sp) -> f sp) <$> spanned m
-
-whitespace :: CharParsing m => m Whitespace
-whitespace =
-  (char ' ' $> Space) <|>
-  (char '\t' $> Tab) <|>
-  (Continued <$ char '\\' <*> newline <*> many whitespace)
-
-anyWhitespace :: CharParsing m => m Whitespace
-anyWhitespace = whitespace <|> Newline <$> newline
-
-identifier :: (TokenParsing m, DeltaParsing m) => m Whitespace -> m (Ident '[] Span)
-identifier ws =
-  annotated $
-  (\a b c -> MkIdent c a b) <$>
-  runUnspaced (ident idStyle) <*>
-  many ws
-
-commaSep :: (CharParsing m, Monad m) => m a -> m (CommaSep a)
-commaSep e = someCommaSep <|> pure CommaSepNone
-  where
-    someCommaSep =
-      (\val -> maybe (CommaSepOne val) ($ val)) <$>
-      e <*>
-      optional
-        ((\a b c -> CommaSepMany c a b) <$>
-          (char ',' *> many whitespace) <*>
-          commaSep e)
-
-commaSep1 :: (CharParsing m, Monad m) => m a -> m (CommaSep1 a)
-commaSep1 e =
-  (\val -> maybe (CommaSepOne1 val) ($ val)) <$>
-  e <*>
-  optional
-    ((\a b c -> CommaSepMany1 c a b) <$>
-     (char ',' *> many whitespace) <*>
-     commaSep1 e)
-
-commaSep1' :: (CharParsing m, Monad m) => m Whitespace -> m a -> m (CommaSep1' a)
-commaSep1' ws e = do
-  e' <- e
-  ws' <- optional (char ',' *> many ws)
-  case ws' of
-    Nothing -> pure $ CommaSepOne1' e' Nothing
-    Just ws'' ->
-      maybe (CommaSepOne1' e' $ Just ws'') (CommaSepMany1' e' ws'') <$>
-      optional (commaSep1' ws e)
-
-parameter :: DeltaParsing m => m (Untagged Param Span)
-parameter =
-  (\a b c -> maybe (PositionalParam c a) (uncurry $ KeywordParam c a) b) <$>
-  identifier anyWhitespace <*>
-  optional
-    ((,) <$>
-     (char '=' *> many anyWhitespace) <*>
-     exprNoList anyWhitespace) <|>
-  char '*' *>
-  ((\a b c -> DoubleStarParam c a b) <$
-   char '*' <*> many anyWhitespace <*>
-   identifier anyWhitespace <|>
-
-   (\a b c -> StarParam c a b) <$>
-   many anyWhitespace <*>
-   identifier anyWhitespace)
-
-argument :: DeltaParsing m => m (Untagged Arg Span)
-argument = stars <|> nonStars
-  where
-    stars =
-      char '*' *>
-      ((\a b c -> DoubleStarArg c a b) <$
-       char '*' <*>
-       many anyWhitespace <*>
-       exprNoList anyWhitespace
-       <|>
-       (\a b c -> StarArg c a b) <$>
-       many anyWhitespace <*>
-       exprNoList anyWhitespace)
-
-    nonStars = do
-      e <- exprNoList anyWhitespace
-      case e of
-        Ident _ f ->
-          (\a b -> maybe (PositionalArg b e) (uncurry $ KeywordArg b f) a) <$>
-          optional
-            ((,) <$>
-            (char '=' *> many anyWhitespace) <*>
-            exprNoList anyWhitespace)
-        _ -> pure $ flip PositionalArg e
-
-stringPrefix :: CharParsing m => m StringPrefix
-stringPrefix =
-  (char 'r' *> (char 'b' $> Prefix_rb <|> char 'B' $> Prefix_rB <|> pure Prefix_r)) <|>
-  (char 'R' *> (char 'b' $> Prefix_Rb <|> char 'B' $> Prefix_RB <|> pure Prefix_R)) <|>
-  (char 'b' *> (char 'r' $> Prefix_br <|> char 'R' $> Prefix_bR <|> pure Prefix_b)) <|>
-  (char 'B' *> (char 'r' $> Prefix_Br <|> char 'R' $> Prefix_BR <|> pure Prefix_B)) <|>
-  (char 'u' $> Prefix_u) <|>
-  (char 'U' $> Prefix_U)
-
-expr :: DeltaParsing m => m Whitespace -> m (Expr '[] Span)
-expr ws = tuple_list
-  where
-    tuple_list =
-      annotated $
-      (\a b c -> either (const a) (uncurry (Tuple c a)) b) <$>
-      exprNoList ws <*>
-      (fmap Left (notFollowedBy $ char ',') <|>
-       fmap Right
-         ((,) <$> (char ',' *> many ws) <*> optional (commaSep1' ws (exprNoList ws))))
-
-exprNoList :: DeltaParsing m => m Whitespace -> m (Expr '[] Span)
-exprNoList ws = orExpr ws
-  where
-    atom =
-      bool <|>
-      none <|>
-      strLit <|>
-      int <|>
-      ident' <|>
-      list <|>
-      parenthesis <|>
-      not
-
-    not =
-      annotated $
-      (\a b c -> Not c a b) <$>
-      (reserved "not" *> many ws) <*>
-      exprNoList ws
-
-    ident' =
-      annotated $
-      flip Ident <$> identifier ws
-
-    list =
-      annotated $
-      (\a b c d -> List d a b c) <$
-      char '[' <*>
-      many anyWhitespace <*>
-      commaSep (orExpr anyWhitespace) <*>
-      (char ']' *> many ws)
-
-    bool =
-      annotated $
-      (\a b c -> Bool c a b) <$>
-      (reserved "True" $> True <|> reserved "False" $> False) <*>
-      many ws
-
-    none =
-      annotated $
-      flip None <$
-      reserved "None" <*>
-      many ws
-
-    tripleSingle = try (string "''") *> char '\'' <?> "'''"
-    tripleDouble = try (string "\"\"") *> char '"' <?> "\"\"\""
-
-    strLit =
-      annotated $
-      ((\a b c d -> String d a LongSingle b c) <$>
-         try (optional stringPrefix <* tripleSingle) <*>
-         manyTill stringChar (string "'''") <|>
-       (\a b c d -> String d a LongDouble b c) <$>
-         try (optional stringPrefix <* tripleDouble) <*>
-         manyTill stringChar (string "\"\"\"") <|>
-       (\a b c d -> String d a ShortSingle b c) <$>
-         try (optional stringPrefix <* char '\'') <*>
-         manyTill stringChar (char '\'') <|>
-       (\a b c d -> String d a ShortDouble b c) <$>
-         try (optional stringPrefix <* char '\"') <*>
-         manyTill stringChar (char '\"')) <*>
-      many ws
-
-    int =
-      annotated $
-      (\a b c -> Int c (read a) b) <$>
-      some digit <*>
-      many ws
-
-    parenthesis =
-      annotated $
-      (\a b c d -> Parens d a b c) <$>
-      (char '(' *> many anyWhitespace) <*>
-      expr anyWhitespace <*> (char ')' *> many ws)
-
-    binOpL inner p = chainl1 inner $ do
-      (op, s) <- do
-        op :~ s <- spanned p
-        pure (op, s)
-      pure $ \a b -> BinOp (a ^. exprAnnotation <> b ^. exprAnnotation) a (op $> s) b
-
-    orExpr ws' = binOpL (andExpr ws') (BoolOr () <$> (reserved "or" *> many ws'))
-
-    andExpr ws' = binOpL (notExpr ws') (BoolAnd () <$> (reserved "and" *> many ws'))
-
-    notExpr = comparison
-
-    comparison ws' = binOpL (bitOr ws') $
-      Is () <$> (reserved "is" *> many ws') <|>
-      Equals () <$> (string "==" *> many ws')
-
-    bitOr = bitXor
-
-    bitXor = bitAnd
-
-    bitAnd = bitShift
-
-    bitShift = arith
-
-    arith ws' = binOpL (term ws') $
-      Plus () <$> (char '+' *> many ws') <|>
-      Minus () <$> (char '-' *> many ws')
-
-    term ws' = binOpL (factor ws' ) $
-      Multiply () <$> (char '*' *> many ws') <|>
-      Divide () <$> (char '/' *> many ws')
-
-    factor ws' =
-      annotated ((\a b c -> Negate c a b) <$ char '-' <*> many ws' <*> factor ws') <|>
-      power ws'
-
-    power ws' = do
-      a <- atomExpr ws'
-      v <-
-        optional
-          (try ((,,) <$> spanned (string "**")) <*>
-           many ws' <*>
-           factor ws')
-      case v of
-        Nothing -> pure a
-        Just (_ :~ s, ws2, b) ->
-          pure $ BinOp (a ^. exprAnnotation <> b ^. exprAnnotation) a (Exp s ws2) b
-
-    atomExpr ws' =
-      (\a afters -> case afters of; [] -> a; _ -> foldl' (&) a afters) <$>
-      atom <*>
-      many (deref <|> call)
-      where
-        deref =
-          (\ws1 (str :~ s) a -> Deref (a ^. exprAnnotation <> s) a ws1 str) <$>
-          (char '.' *> many ws') <*>
-          spanned (identifier ws')
-        call =
-          (\ws1 (csep :~ s) ws2 a -> Call (a ^. exprAnnotation <> s) a ws1 csep ws2) <$>
-          (char '(' *> many anyWhitespace) <*>
-          spanned (commaSep (annotated argument)) <*>
-          (char ')' *> many ws')
-
-indent :: (CharParsing m, MonadState [[Whitespace]] m) => m ()
-indent = do
-  level
-  ws <- some whitespace <?> "indent"
-  modify (ws :)
-
-level :: (CharParsing m, MonadState [[Whitespace]] m) => m ()
-level = (get >>= foldl (\b a -> b <* traverse parseWs a) (pure ())) <?> "level indentation"
-  where
-    parseWs Space = char ' '$> ()
-    parseWs Tab = char '\t' $> ()
-    parseWs (Continued nl ws) = pure ()
-    parseWs Newline{} = error "newline in indentation state"
-
-dedent :: MonadState [[Whitespace]] m => m ()
-dedent = modify $ \case; [] -> error "cannot dedent further"; _:xs -> xs
-
-block :: (DeltaParsing m, MonadState [[Whitespace]] m) => m (Block '[] Span)
-block = fmap Block ((\(a :| b) c -> a :| (b ++ c)) <$> firsts <*> go) <* dedent
-  where
-    firsts =
-      liftA2 NonEmpty.cons
-        (annotated $
-         (\a b d -> (d, a, b)) <$>
-         try (many whitespace <* notFollowedBy (noneOf "#\r\n")) <*>
-         fmap Left ((,) <$> optional comment <*> newline))
-        firsts
-      <|>
-      fmap pure
-        (annotated $
-         (\a b d -> (d, a, b)) <$>
-         (indent *> fmap head get) <*>
-         (Right <$> statement))
-
-    go =
-      many $
-      (\(f :~ a) -> f a) <$>
-      spanned
-        (((\a b d -> (d, a, b)) <$>
-         try (many whitespace <* notFollowedBy (noneOf "#\r\n")) <*>
-         fmap Left ((,) <$> optional comment <*> newline)) <|>
-
-        ((\a b d -> (d, a, b)) <$>
-         (try level *> fmap head get) <*>
-         (Right <$> statement)))
-
-exceptAs :: DeltaParsing m => m (ExceptAs '[] Span)
-exceptAs =
-  annotated $
-  (\a b c -> ExceptAs c a b) <$>
-  expr whitespace <*>
-  optional
-    ((,) <$ string "as" <*> many whitespace <*> identifier whitespace)
-
-compoundStatement
-  :: (DeltaParsing m, MonadState [[Whitespace]] m) => m (CompoundStatement '[] Span)
-compoundStatement =
-  annotated $
-  (fundef <?> "function definition") <|>
-  (ifSt <?> "if statement") <|>
-  (while <?> "while statement") <|>
-  (trySt <?> "try statement") <|>
-  (for <?> "for statement") <|>
-  (classSt <?> "class definition")
-  where
-    trySt =
-      (\b c d e f g ->
-         either
-           (\(h, m, n) -> TryExcept g b c d e h m n)
-           (\(h, i, j, k) -> TryFinally g b c d e h i j k)
-           f) <$
-      reserved "try" <*>
-      many whitespace <*
-      char ':' <*>
-      many whitespace <*>
-      newline <*>
-      block <*>
-      (fmap Left
-       ((,,) <$>
-        some1
-          ((,,,,) <$
-           reserved "except" <*>
-           many whitespace <*>
-           exceptAs <*
-           char ':' <*>
-           many whitespace <*>
-           newline <*>
-           block) <*>
-        optional
-          ((,,,) <$ string "else" <*>
-           many whitespace <* char ':' <*> many whitespace <*> newline <*>
-           block) <*>
-        optional
-          ((,,,) <$ string "finally" <*>
-           many whitespace <* char ':' <*> many whitespace <*> newline <*>
-           block)) <|>
-
-       fmap Right
-       ((,,,) <$
-        reserved "finally" <*>
-        many whitespace <*
-        char ':' <*>
-        many whitespace <*>
-        newline <*>
-        block))
-
     fundef =
-      (\a b c d e f g h i -> Fundef i a b c d e f g h) <$
-      reserved "def" <*> some1 whitespace <*> identifier whitespace <*
-      char '(' <*> many whitespace <*> commaSep (annotated parameter) <*
-      char ')' <*> many whitespace <* char ':' <*> many whitespace <*> newline <*>
-      block
+      (\(tkDef, defSpaces) -> Fundef (pyTokenAnn tkDef) (NonEmpty.fromList defSpaces)) <$>
+      token (TkDef ()) <*>
+      identifier <*>
+      fmap snd (token $ TkLeftParen ()) <*>
+      commaSep param <*>
+      fmap snd (token $ TkRightParen ()) <*>
+      fmap snd (token $ TkColon ()) <*>
+      eol <*
+      indent <*>
+      block <*
+      dedent
 
-    ifSt =
-      (\a b c d e f h -> If h a b c d e f) <$
-      reserved "if" <*> many whitespace <*>
-      expr whitespace <* char ':' <*>
-      many whitespace <*> newline <*> block <*>
-      optional
-        ((,,,) <$> (reserved "else" *> many whitespace) <*
-         char ':' <*> many whitespace <*> newline <*> block)
-
-    while =
-      (\a b c d e g -> While g a b c d e) <$
-      reserved "while" <*> many whitespace <*>
-      expr whitespace <* char ':' <*>
-      many whitespace <*> newline <*> block
-
-    for =
-      (\a b c d e f g h i -> For i a b c d e f g h) <$
-      reserved "for" <*> many whitespace <*> expr whitespace <*
-      reserved "in" <*> many whitespace <*> expr whitespace <*
-      char ':' <*> many whitespace <*> newline <*>
-      block <*>
-      optional
-        ((,,,) <$ reserved "else" <*>
-         many whitespace <* char ':' <*>
-         many whitespace <*> newline <*>
-         block)
-
-    classSt =
-      (\a b c d e f g -> ClassDef g a b c d e f) <$
-      reserved "class" <*> some1 whitespace <*>
-      identifier whitespace <*>
-      optional
-        ((,,) <$>
-         (char '(' *> many anyWhitespace) <*>
-         optional (commaSep1 (annotated argument)) <*>
-         (char ')' *> many whitespace)) <*>
-      (char ':' *> many whitespace) <*>
-      newline <*>
-      block
-
-smallStatement :: (DeltaParsing m, MonadState [[Whitespace]] m) => m (SmallStatement '[] Span)
-smallStatement =
-  annotated $
-  (returnSt <?> "return statement") <|>
-  assignOrExpr <|>
-  (pass <?> "pass statement") <|>
-  (from <?> "import statement") <|>
-  (import_ <?> "import statement") <|>
-  (break <?> "break statement") <|>
-  (continue <?> "continue statement") <|>
-  (raise <?> "raise statement")
-  where
-    break = reserved "break" $> Break
-    continue = reserved "continue" $> Continue
-    pass = reserved "pass" $> Pass
-
-    raise =
-      (\a b c -> Raise c a b) <$
-      reserved "raise" <*>
-      many whitespace <*>
-      optional
-        ((,) <$>
-         exprNoList whitespace <*>
-         optional ((,) <$ reserved "as" <*> many whitespace <*> exprNoList whitespace))
-
-    assignOrExpr = do
-      e <- expr whitespace <?> "expression"
-      mws <- optional (many whitespace <* char '=')
-      case mws of
-        Nothing -> pure (`Expr` e)
-        Just ws ->
-          (\a b c -> Assign c e ws a b) <$>
-          many whitespace <*>
-          expr whitespace
-
-    returnSt =
-      (\a b c -> Return c a b) <$ reserved "return" <*> many whitespace <*> expr whitespace
-
-    dot = Dot <$> (char '.' *> many whitespace)
-
-    importTargets =
-      annotated $
-      (char '*' $> flip ImportAll <*> many whitespace) <|>
-      ((\a b c d -> ImportSomeParens d a b c) <$>
-       (char '(' *> many anyWhitespace) <*>
-       commaSep1' anyWhitespace (importAs anyWhitespace identifier) <*>
-       manyTill anyWhitespace (char ')')) <|>
-      flip ImportSome <$> commaSep1 (importAs whitespace identifier)
-
-    importAs ws p =
-      annotated $
-      (\a b c -> ImportAs c a b) <$>
-      p ws <*>
-      optional (string "as" $> (,) <*> some1 ws <*> identifier ws)
-
-    moduleName ws =
-      annotated $
-      (\a c d -> maybe (ModuleNameOne d a) (\(x, y) -> ModuleNameMany d a x y) c) <$>
-      identifier ws <*>
-      optional
-        ((,) <$> (char '.' *> many ws) <*> moduleName ws)
-
-    relativeModuleName =
-      (\ds -> either (RelativeWithName ds) (Relative $ NonEmpty.fromList ds)) <$>
-      some dot <*>
-      (Left <$> moduleName whitespace <|> Right <$> some whitespace)
-      <|>
-      RelativeWithName [] <$> moduleName whitespace
-
-    from =
-      (\a b c d e f -> From f a b d e) <$>
-      (reserved "from" *> some whitespace) <*>
-      relativeModuleName <*>
-      reserved "import" <*>
-      many whitespace <*>
-      importTargets
-
-    import_ =
-      (\a b c -> Import c a b) <$>
-      (reserved "import" *> some1 whitespace) <*>
-      commaSep1 (importAs whitespace moduleName)
-
-statement :: (DeltaParsing m, MonadState [[Whitespace]] m) => m (Statement '[] Span)
-statement =
-  CompoundStatement <$> compoundStatement <|>
-  smallStatements
-  where
-    smallStatements =
-      SmallStatements <$>
-      smallStatement <*>
-      many
-        (try $
-         (,) <$
-         char ';' <*>
-         many whitespace <*>
-         smallStatement) <*>
-      optional (char ';' *> many whitespace) <*>
-      (Just <$> newline <|> Nothing <$ eof)
-
-comment :: DeltaParsing m => m Comment
-comment = (Comment <$ char '#' <*> many (noneOf "\n\r")) <?> "comment"
-
-module_ :: DeltaParsing m => m (Module '[] Span)
+module_ :: Parser ann (Module '[] ann)
 module_ =
   Module <$>
-  many
-    (try (fmap Left $ (,,) <$> many whitespace <*> optional comment <*> newline) <|>
-     Right <$> evalStateT statement [])
-  <* eof
+  many (Left <$> maybeComment <!> Right <$> statement)
+  where
+    maybeComment =
+      (\ws (cmt, nl) -> (ws, cmt, nl)) <$>
+      fmap fst indents <*>
+      (maybe (Nothing, Nothing) (\(a, b) -> (Just a, Just b)) <$>
+       optional comment
+
+       <!>
+
+       fmap ((,) Nothing) (Just <$> eol <!> Nothing <$ eof))

--- a/src/Language/Python/Internal/Parse.hs
+++ b/src/Language/Python/Internal/Parse.hs
@@ -634,7 +634,8 @@ compoundStatement =
   fundef <!>
   ifSt <!>
   whileSt <!>
-  trySt
+  trySt <!>
+  classSt
   where
     fundef =
       (\(tkDef, defSpaces) -> Fundef (pyTokenAnn tkDef) (NonEmpty.fromList defSpaces)) <$>
@@ -695,6 +696,17 @@ compoundStatement =
              ((,,,) <$>
               (snd <$> token space (TkFinally ())) <*>
               (snd <$> colon space) `thenSuite` ())))
+
+    classSt =
+      (\(tk, s) -> ClassDef (pyTokenAnn tk) $ NonEmpty.fromList s) <$>
+      token space (TkClass ()) <*>
+      identifier space <*>
+      optional
+        ((,,) <$>
+         (snd <$> token anySpace (TkLeftParen ())) <*>
+         optional (commaSep1 anySpace arg) <*>
+         (snd <$> token space (TkRightParen ()))) <*>
+      (snd <$> colon space) `thenSuite` ()
 
 module_ :: Parser ann (Module '[] ann)
 module_ =

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -263,7 +263,7 @@ renderSmallStatement (Raise _ ws x) =
        renderExpr b <>
        foldMap
          (\(d, e) ->
-            "as" <> foldMap renderWhitespace d <>
+            "from" <> foldMap renderWhitespace d <>
             renderExpr e)
          c)
     x

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -8,6 +8,7 @@ import Control.Lens.Wrapped
 import Data.Char (ord)
 import Data.Maybe
 import Data.Semigroup (Semigroup(..))
+
 import Language.Python.Internal.Syntax
 
 bracket :: String -> String
@@ -174,7 +175,10 @@ renderExpr :: Expr v a -> String
 renderExpr (Not _ ws e) =
   "not" <>
   foldMap renderWhitespace ws <>
-  bracketTuple e
+  case e of
+    BinOp _ _ BoolAnd{} _ -> "(" <> renderExpr e <> ")"
+    BinOp _ _ BoolOr{} _ -> "(" <> renderExpr e <> ")"
+    _ -> bracketTuple e
 renderExpr (Parens _ ws1 e ws2) =
   "(" <> foldMap renderWhitespace ws1 <>
   renderExpr e <> ")" <> foldMap renderWhitespace ws2
@@ -302,7 +306,7 @@ renderBlock =
   foldMap
     (either
        (\(x, y, z) ->
-          OneLine $ renderIndents x <> foldMap renderComment y <> renderNewline z)
+          OneLine $ foldMap renderWhitespace x <> foldMap renderComment y <> renderNewline z)
         renderStatement) .
   view _Wrapped
 

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -324,7 +324,7 @@ renderCompoundStatement (If _ ws1 expr ws3 nl body body') =
       fmap
         (\(ws4, ws5, _, _) ->
            "else" <> foldMap renderWhitespace ws4 <> ":" <>
-           foldMap renderWhitespace ws4)
+           foldMap renderWhitespace ws5)
         body' <*>
       fmap (\(_, _, nl2, _) -> nl2) body' <*>
       fmap (\(_, _, _, body'') -> renderBlock body'') body'
@@ -461,6 +461,8 @@ renderModule (Module ms) =
   foldMap
     (either
        (\(a, b, c) ->
-          foldMap renderWhitespace a <> foldMap renderComment b <> foldMap renderNewline c)
+          foldMap renderWhitespace a <>
+          foldMap renderComment b <>
+          foldMap renderNewline c)
        (renderLines . renderStatement))
     ms

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -184,7 +184,13 @@ renderExpr (Int _ n ws) = show n <> foldMap renderWhitespace ws
 renderExpr (Ident _ name) = renderIdent name
 renderExpr (List _ ws1 exprs ws2) =
   "[" <> foldMap renderWhitespace ws1 <>
-  foldMap (renderCommaSep1' renderExpr) exprs <>
+  foldMap
+    (renderCommaSep1' $
+     \e ->
+       case e of
+         Tuple{} -> "(" <> renderExpr e <> ")"
+         _ -> renderExpr e)
+    exprs <>
   "]" <> foldMap renderWhitespace ws2
 renderExpr (Call _ expr ws args ws2) =
   (case expr of
@@ -264,8 +270,8 @@ renderSmallStatement (Raise _ ws x) =
 renderSmallStatement (Return _ ws expr) =
   "return" <> foldMap renderWhitespace ws <> renderExpr expr
 renderSmallStatement (Expr _ expr) = renderExpr expr
-renderSmallStatement (Assign _ lvalue ws1 ws2 rvalue) =
-  renderExpr lvalue <> foldMap renderWhitespace ws1 <> "=" <>
+renderSmallStatement (Assign _ lvalue ws2 rvalue) =
+  renderExpr lvalue <> "=" <>
   foldMap renderWhitespace ws2 <> renderExpr rvalue
 renderSmallStatement (Pass _) = "pass"
 renderSmallStatement (Continue _) = "continue"

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -260,7 +260,7 @@ renderSmallStatement (Raise _ ws x) =
   "raise" <> foldMap renderWhitespace ws <>
   foldMap
     (\(b, c) ->
-       renderExpr b <>
+       bracketTuple b <>
        foldMap
          (\(d, e) ->
             "from" <> foldMap renderWhitespace d <>
@@ -330,7 +330,7 @@ renderCompoundStatement (If _ ws1 expr ws3 nl body body') =
       fmap (\(_, _, _, body'') -> renderBlock body'') body'
 renderCompoundStatement (While _ ws1 expr ws3 nl body) =
   ManyLines
-    ("while" <> foldMap renderWhitespace ws1 <> renderExpr expr <>
+    ("while" <> foldMap renderWhitespace ws1 <> bracketTuple expr <>
      ":" <> foldMap renderWhitespace ws3)
     nl
     (renderBlock body)

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -316,7 +316,7 @@ renderCompoundStatement (If _ ws1 expr ws3 nl body body') =
   where
     firstLine =
       "if" <> foldMap renderWhitespace ws1 <>
-      renderExpr expr <> ":" <>
+      bracketTuple expr <> ":" <>
       foldMap renderWhitespace ws3
     restLines = renderBlock body <> fromMaybe mempty elseLines
     elseLines =

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -239,8 +239,8 @@ renderDot (Dot ws) = "." <> foldMap renderWhitespace ws
 renderRelativeModuleName :: RelativeModuleName v a -> String
 renderRelativeModuleName (RelativeWithName ds mn) =
   foldMap renderDot ds <> renderModuleName mn
-renderRelativeModuleName (Relative ds ws) =
-  foldMap renderDot ds <> foldMap renderWhitespace ws
+renderRelativeModuleName (Relative ds) =
+  foldMap renderDot ds
 
 renderImportAs :: (e a -> String) -> ImportAs e v a -> String
 renderImportAs f (ImportAs _ ea m) =

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -294,7 +294,7 @@ renderBlock :: Block v a -> Lines String
 renderBlock =
   foldMap
     (\(_, a, b) ->
-       (foldMap renderWhitespace a <>) <$>
+       (foldMap renderWhitespace (unIndent a) <>) <$>
        either
          (\(y, z) ->
             OneLine $ foldMap renderComment y <> renderNewline z)

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -264,7 +264,7 @@ renderSmallStatement (Raise _ ws x) =
        foldMap
          (\(d, e) ->
             "from" <> foldMap renderWhitespace d <>
-            renderExpr e)
+            bracketTuple e)
          c)
     x
 renderSmallStatement (Return _ ws expr) =
@@ -419,8 +419,8 @@ renderStatement (SmallStatements s ss sc nl) =
 
 renderExceptAs :: ExceptAs v a -> String
 renderExceptAs (ExceptAs _ e f) =
-  renderExpr e <>
-  foldMap (\(a, b) -> foldMap renderWhitespace a <> renderIdent b) f
+  bracketTuple e <>
+  foldMap (\(a, b) -> "as" <> foldMap renderWhitespace a <> renderIdent b) f
 
 renderArg :: Arg v a -> String
 renderArg (PositionalArg _ expr) = bracketTuple expr

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -448,6 +448,6 @@ renderModule (Module ms) =
   foldMap
     (either
        (\(a, b, c) ->
-          foldMap renderWhitespace a <> foldMap renderComment b <> renderNewline c)
+          foldMap renderWhitespace a <> foldMap renderComment b <> foldMap renderNewline c)
        (renderLines . renderStatement))
     ms

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -184,7 +184,7 @@ renderExpr (Int _ n ws) = show n <> foldMap renderWhitespace ws
 renderExpr (Ident _ name) = renderIdent name
 renderExpr (List _ ws1 exprs ws2) =
   "[" <> foldMap renderWhitespace ws1 <>
-  renderCommaSep renderExpr exprs <>
+  foldMap (renderCommaSep1' renderExpr) exprs <>
   "]" <> foldMap renderWhitespace ws2
 renderExpr (Call _ expr ws args ws2) =
   (case expr of

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -394,19 +394,22 @@ renderCompoundStatement (ClassDef _ a b c d e f) =
 renderStatement :: Statement v a -> Lines String
 renderStatement (CompoundStatement c) = renderCompoundStatement c
 renderStatement (SmallStatements s ss sc nl) =
-  ManyLines
-  (renderSmallStatement s <>
-   foldMap
-     (\(b, c) ->
-        ";" <>
-        foldMap renderWhitespace b <>
-        renderSmallStatement c)
-     ss <>
-   foldMap
-     (\b -> ";" <> foldMap renderWhitespace b)
-     sc)
-  nl
-  NoLines
+  f $
+  renderSmallStatement s <>
+  foldMap
+    (\(b, c) ->
+       ";" <>
+       foldMap renderWhitespace b <>
+       renderSmallStatement c)
+    ss <>
+  foldMap
+    (\b -> ";" <> foldMap renderWhitespace b)
+    sc
+  where
+    f a =
+      case nl of
+        Nothing -> OneLine a
+        Just nl' -> ManyLines a nl' NoLines
 
 renderExceptAs :: ExceptAs v a -> String
 renderExceptAs (ExceptAs _ e f) =

--- a/src/Language/Python/Internal/Syntax/CommaSep.hs
+++ b/src/Language/Python/Internal/Syntax/CommaSep.hs
@@ -40,6 +40,10 @@ data CommaSep1 a
   | CommaSepMany1 a [Whitespace] (CommaSep1 a)
   deriving (Eq, Show, Functor, Foldable, Traversable)
 
+commaSep1Head :: CommaSep1 a -> a
+commaSep1Head (CommaSepOne1 a) = a
+commaSep1Head (CommaSepMany1 a _ _) = a
+
 instance Semigroup (CommaSep1 a) where
   a <> b =
     CommaSepMany1

--- a/src/Language/Python/Internal/Syntax/CommaSep.hs
+++ b/src/Language/Python/Internal/Syntax/CommaSep.hs
@@ -24,6 +24,7 @@ data CommaSep a
 listToCommaSep :: [a] -> CommaSep a
 listToCommaSep [] = CommaSepNone
 listToCommaSep [a] = CommaSepOne a
+  
 listToCommaSep (a:as) = CommaSepMany a [Space] $ listToCommaSep as
 
 appendCommaSep :: CommaSep a -> CommaSep a -> CommaSep a
@@ -78,6 +79,12 @@ data CommaSep1' a
   = CommaSepOne1' a (Maybe [Whitespace])
   | CommaSepMany1' a [Whitespace] (CommaSep1' a)
   deriving (Eq, Show, Functor, Foldable, Traversable)
+
+listToCommaSep1' :: [a] -> Maybe (CommaSep1' a)
+listToCommaSep1' [] = Nothing
+listToCommaSep1' [a] = Just (CommaSepOne1' a Nothing)
+listToCommaSep1' (a:as) =
+  CommaSepMany1' a [Space] <$> listToCommaSep1' as
 
 instance Token s t => Token (CommaSep1' s) (CommaSep1' t) where
   unvalidate = fmap unvalidate

--- a/src/Language/Python/Internal/Syntax/CommaSep.hs
+++ b/src/Language/Python/Internal/Syntax/CommaSep.hs
@@ -99,7 +99,8 @@ instance Token s t => Token (CommaSep1' s) (CommaSep1' t) where
              CommaSepOne1'
                (fromMaybe (a & whitespaceAfter .~ ws) $ b $> unvalidate a)
                (b $> ws)
-           CommaSepMany1' a b c -> CommaSepMany1' (unvalidate a) b (c & whitespaceAfter .~ ws))
+           CommaSepMany1' a b c ->
+             CommaSepMany1' (unvalidate a) b (c & whitespaceAfter .~ ws))
 
   startChar (CommaSepOne1' a _) = startChar a
   startChar (CommaSepMany1' a _ _) = startChar a

--- a/src/Language/Python/Internal/Syntax/Expr.hs
+++ b/src/Language/Python/Internal/Syntax/Expr.hs
@@ -94,7 +94,7 @@ data Expr (v :: [*]) a
   -- [ spaces
   , _unsafeListWhitespaceLeft :: [Whitespace]
   -- exprs
-  , _unsafeListValues :: CommaSep (Expr v a)
+  , _unsafeListValues :: Maybe (CommaSep1' (Expr v a))
   -- ] spaces
   , _unsafeListWhitespaceRight :: [Whitespace]
   }

--- a/src/Language/Python/Internal/Syntax/Expr.hs
+++ b/src/Language/Python/Internal/Syntax/Expr.hs
@@ -231,13 +231,7 @@ instance Token (Expr v a) (Expr '[] a) where
           String _ _ _ _ ws -> ws
           Not _ _ e -> e ^. getting whitespaceAfter
           Tuple _ _ ws Nothing -> ws
-          Tuple _ _ _ (Just cs) -> go cs
-            where
-              go cs =
-                case cs of
-                  CommaSepOne1' e Nothing -> e ^. getting whitespaceAfter
-                  CommaSepOne1' _ (Just ws) -> ws
-                  CommaSepMany1' _ _ rest -> go rest)
+          Tuple _ _ _ (Just cs) -> cs ^. getting whitespaceAfter)
       (\e ws ->
         case e of
           None a _ -> None a ws

--- a/src/Language/Python/Internal/Syntax/Module.hs
+++ b/src/Language/Python/Internal/Syntax/Module.hs
@@ -1,10 +1,16 @@
 {-# language TemplateHaskell, TypeFamilies, FlexibleInstances, MultiParamTypeClasses #-}
-{-# language DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
 module Language.Python.Internal.Syntax.Module where
 
+import Control.Lens.Fold (foldMapOf, folded)
+import Control.Lens.Setter (over, mapped)
 import Control.Lens.TH (makeWrapped)
+import Control.Lens.Traversal (traverseOf)
+import Control.Lens.Tuple (_1)
 import Control.Lens.Prism (_Right)
 import Control.Lens.Wrapped (_Wrapped)
+import Data.Bifunctor (bimap)
+import Data.Bifoldable (bifoldMap)
+import Data.Bitraversable (bitraverse)
 
 import Language.Python.Internal.Syntax.Comment
 import Language.Python.Internal.Syntax.Statement
@@ -12,10 +18,20 @@ import Language.Python.Internal.Syntax.Whitespace
 
 newtype Module v a
   = Module
-  { unModule :: [Either ([Whitespace], Maybe Comment, Maybe Newline) (Statement v a)]
-  } deriving (Eq, Show, Functor, Foldable, Traversable)
+  { unModule :: [Either (Indents a, Maybe Comment, Maybe Newline) (Statement v a)]
+  } deriving (Eq, Show)
 
 instance HasStatements Module where
   _Statements = _Wrapped.traverse._Right
+
+instance Functor (Module v) where
+  fmap f (Module m) = Module $ fmap (bimap (over (_1.mapped) f) (fmap f)) m
+
+instance Foldable (Module v) where
+  foldMap f (Module m) = foldMap (bifoldMap (foldMapOf (_1.folded) f) (foldMap f)) m
+
+instance Traversable (Module v) where
+  traverse f (Module m) =
+    Module <$> traverse (bitraverse (traverseOf (_1.traverse) f) (traverse f)) m
 
 makeWrapped ''Module

--- a/src/Language/Python/Internal/Syntax/Module.hs
+++ b/src/Language/Python/Internal/Syntax/Module.hs
@@ -10,8 +10,10 @@ import Language.Python.Internal.Syntax.Comment
 import Language.Python.Internal.Syntax.Statement
 import Language.Python.Internal.Syntax.Whitespace
 
-newtype Module v a = Module [Either ([Whitespace], Maybe Comment, Newline) (Statement v a)]
-  deriving (Eq, Show, Functor, Foldable, Traversable)
+newtype Module v a
+  = Module
+  { unModule :: [Either ([Whitespace], Maybe Comment, Maybe Newline) (Statement v a)]
+  } deriving (Eq, Show, Functor, Foldable, Traversable)
 
 instance HasStatements Module where
   _Statements = _Wrapped.traverse._Right

--- a/src/Language/Python/Internal/Syntax/ModuleNames.hs
+++ b/src/Language/Python/Internal/Syntax/ModuleNames.hs
@@ -3,12 +3,15 @@
 {-# language LambdaCase #-}
 module Language.Python.Internal.Syntax.ModuleNames where
 
+import Control.Lens.Cons (_last)
+import Control.Lens.Fold ((^?!))
 import Control.Lens.Getter ((^.), getting)
 import Control.Lens.Lens (lens)
 import Control.Lens.Setter ((.~))
 import Data.Coerce (coerce)
 import Data.Function ((&))
-import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.List.NonEmpty as NonEmpty
 
 import Language.Python.Internal.Syntax.Ident
 import Language.Python.Internal.Syntax.Token
@@ -16,7 +19,7 @@ import Language.Python.Internal.Syntax.Whitespace
 
 data RelativeModuleName v a
   = RelativeWithName [Dot] (ModuleName v a)
-  | Relative (NonEmpty Dot) [Whitespace]
+  | Relative (NonEmpty Dot)
   deriving (Eq, Show, Functor, Foldable, Traversable)
 
 instance Token (RelativeModuleName v a) (RelativeModuleName '[] a) where
@@ -25,25 +28,46 @@ instance Token (RelativeModuleName v a) (RelativeModuleName '[] a) where
     lens
       (\case
           RelativeWithName _ mn -> mn ^. getting whitespaceAfter
-          Relative _ ws -> ws)
+          Relative (a :| as) -> (a : as) ^?! _last.whitespaceAfter)
       (\a ws -> case a of
           RelativeWithName x mn -> RelativeWithName x (mn & whitespaceAfter .~ ws)
-          Relative x _ -> Relative x ws)
+          Relative (a :| as) ->
+            Relative .
+            NonEmpty.fromList $
+            (a : as) & _last.whitespaceAfter .~ ws)
 
   startChar (RelativeWithName [] mn) = startChar mn
   startChar (RelativeWithName (_:_) mn) = '.'
-  startChar (Relative _ _) = '.'
+  startChar (Relative _) = '.'
 
   endChar (RelativeWithName _ mn) = endChar mn
-  endChar (Relative _ _) = '.'
+  endChar (Relative _) = '.'
 
 data Dot = Dot [Whitespace]
   deriving (Eq, Show)
+
+instance Token Dot Dot where
+  unvalidate = id
+  whitespaceAfter =
+    lens (\(Dot ws) -> ws) (\_ ws -> Dot ws)
+
+  startChar _ = '.'
+  endChar _ = '.'
 
 data ModuleName v a
   = ModuleNameOne a (Ident v a)
   | ModuleNameMany a (Ident v a) [Whitespace] (ModuleName v a)
   deriving (Eq, Show, Functor, Foldable, Traversable)
+
+_moduleNameAnn :: ModuleName v a -> a
+_moduleNameAnn (ModuleNameOne a _) = a
+_moduleNameAnn (ModuleNameMany a _ _ _) = a
+
+makeModuleName :: Ident v a -> [([Whitespace], Ident v a)] -> ModuleName v a
+makeModuleName i [] = ModuleNameOne (_identAnnotation i) i
+makeModuleName i ((a, b) : as) =
+  ModuleNameMany (_identAnnotation i) i a $
+  makeModuleName b as
 
 instance Token (ModuleName v a) (ModuleName '[] a) where
   unvalidate = coerce

--- a/src/Language/Python/Internal/Syntax/Statement.hs
+++ b/src/Language/Python/Internal/Syntax/Statement.hs
@@ -7,6 +7,7 @@
 {-# language UndecidableInstances #-}
 module Language.Python.Internal.Syntax.Statement where
 
+import Control.Lens.Fold (foldMapOf, folded)
 import Control.Lens.Getter ((^.), getting)
 import Control.Lens.Lens (Lens, Lens', lens)
 import Control.Lens.Plated (Plated(..), gplate)
@@ -14,8 +15,11 @@ import Control.Lens.Prism (_Just, _Right)
 import Control.Lens.Setter ((.~), over, mapped)
 import Control.Lens.TH (makeLenses, makeWrapped)
 import Control.Lens.Traversal (Traversal, traverseOf)
-import Control.Lens.Tuple (_2, _3, _4, _5)
+import Control.Lens.Tuple (_1, _2, _5, _6)
 import Control.Lens.Wrapped (_Wrapped)
+import Data.Bifunctor (bimap)
+import Data.Bifoldable (bifoldMap)
+import Data.Bitraversable (bitraverse)
 import Data.Coerce (coerce)
 import Data.Function ((&))
 import Data.List.NonEmpty (NonEmpty)
@@ -76,49 +80,56 @@ newtype Block v a
   = Block
   { unBlock
     :: NonEmpty
-         ( a
-         , Indent
-         , Either
-             (Maybe Comment, Newline)
-             (Statement v a)
-         )
-  }
-  deriving (Eq, Show, Functor, Foldable, Traversable)
+         (Either
+            (Indents a, Maybe Comment, Newline)
+            (Statement v a))
+  } deriving (Eq, Show)
+
+instance Functor (Block v) where
+  fmap f (Block b) = Block $ fmap (bimap (over (_1.mapped) f) (fmap f)) b
+
+instance Foldable (Block v) where
+  foldMap f (Block b) = foldMap (bifoldMap (foldMapOf (_1.folded) f) (foldMap f)) b
+
+instance Traversable (Block v) where
+  traverse f (Block b) =
+    Block <$> traverse (bitraverse (traverseOf (_1.traverse) f) (traverse f)) b
 
 class HasBlocks s where
   _Blocks :: Traversal (s v a) (s '[] a) (Block v a) (Block '[] a)
 
 instance HasBlocks CompoundStatement where
-  _Blocks f (Fundef a ws1 name ws2 params ws3 ws4 nl b) =
-    Fundef a ws1 (coerce name) ws2 (coerce params) ws3 ws4 nl <$> coerce (f b)
-  _Blocks f (If a ws1 e1 ws3 nl b b') =
-    If a ws1 (coerce e1) ws3 nl <$>
+  _Blocks f (Fundef idnt a ws1 name ws2 params ws3 ws4 nl b) =
+    Fundef idnt a ws1 (coerce name) ws2 (coerce params) ws3 ws4 nl <$> coerce (f b)
+  _Blocks f (If idnt a ws1 e1 ws3 nl b b') =
+    If idnt a ws1 (coerce e1) ws3 nl <$>
     coerce (f b) <*>
-    traverseOf (traverse._4) (coerce . f) b'
-  _Blocks f (While a ws1 e1 ws3 nl b) =
-    While a ws1 (coerce e1) ws3 nl <$> coerce (f b)
-  _Blocks fun (TryExcept a b c d e f g h) =
-    TryExcept a (coerce b) (coerce c) (coerce d) <$>
+    traverseOf (traverse._5) (coerce . f) b'
+  _Blocks f (While idnt a ws1 e1 ws3 nl b) =
+    While idnt a ws1 (coerce e1) ws3 nl <$> coerce (f b)
+  _Blocks fun (TryExcept idnt a b c d e f g h) =
+    TryExcept idnt a (coerce b) (coerce c) (coerce d) <$>
     fun e <*>
     -- (coerce f) downcasts the ExceptAs
-    (traverse._5) fun (coerce f) <*>
-    (traverse._4) fun g <*>
-    (traverse._4) fun h
-  _Blocks fun (TryFinally a b c d e f g h i) =
-    TryFinally a (coerce b) (coerce c) (coerce d) <$> fun e <*>
+    (traverse._6) fun (coerce f) <*>
+    (traverse._5) fun g <*>
+    (traverse._5) fun h
+  _Blocks fun (TryFinally idnt a b c d e idnt2 f g h i) =
+    TryFinally idnt a (coerce b) (coerce c) (coerce d) <$> fun e <*> pure idnt2 <*>
     pure (coerce f) <*> pure (coerce g) <*> pure (coerce h) <*> fun i
-  _Blocks fun (For a b c d e f g h i) =
-    For a b (coerce c) d (coerce e) f g <$>
+  _Blocks fun (For idnt a b c d e f g h i) =
+    For idnt a b (coerce c) d (coerce e) f g <$>
     fun h <*>
-    (traverse._4) fun i
-  _Blocks fun (ClassDef a b c d e f g) =
-    ClassDef a b (coerce c) (coerce d) e f <$> fun g
+    (traverse._5) fun i
+  _Blocks fun (ClassDef idnt a b c d e f g) =
+    ClassDef idnt a b (coerce c) (coerce d) e f <$> fun g
 
 instance HasStatements Block where
-  _Statements = _Wrapped.traverse._3._Right
+  _Statements = _Wrapped.traverse._Right
 
 data Statement (v :: [*]) a
   = SmallStatements
+      (Indents a)
       (SmallStatement v a)
       [([Whitespace], SmallStatement v a)]
       (Maybe [Whitespace])
@@ -129,40 +140,40 @@ data Statement (v :: [*]) a
 
 instance HasBlocks Statement where
   _Blocks f (CompoundStatement c) = CompoundStatement <$> _Blocks f c
-  _Blocks _ (SmallStatements a b c d) =
-    pure $ SmallStatements (coerce a) (over (mapped._2) coerce b) c d
+  _Blocks _ (SmallStatements idnt a b c d) =
+    pure $ SmallStatements idnt (coerce a) (over (mapped._2) coerce b) c d
 
 instance Plated (Statement '[] a) where
   plate _ s@SmallStatements{} = pure s
   plate fun (CompoundStatement s) =
     CompoundStatement <$>
     case s of
-      Fundef a ws1 b ws2 c ws3 ws4 nl sts ->
-        Fundef a ws1 b ws2 c ws3 ws4 nl <$> (_Wrapped.traverse._3._Right) fun sts
-      If a ws1 b ws3 nl sts sts' ->
-        If a ws1 b ws3 nl <$>
-        (_Wrapped.traverse._3._Right) fun sts <*>
-        (traverse._4._Wrapped.traverse._3._Right) fun sts'
-      While a ws1 b ws3 nl sts ->
-        While a ws1 b ws3 nl <$> (_Wrapped.traverse._3._Right) fun sts
-      TryExcept a b c d e f g h ->
-        TryExcept a b c d <$> (_Wrapped.traverse._3._Right) fun e <*>
-        (traverse._5._Wrapped.traverse._3._Right) fun f <*>
-        (traverse._4._Wrapped.traverse._3._Right) fun g <*>
-        (traverse._4._Wrapped.traverse._3._Right) fun h
-      TryFinally a b c d e f g h i ->
-        TryFinally a b c d <$> (_Wrapped.traverse._3._Right) fun e <*>
-        pure f <*> pure g <*> pure h <*> (_Wrapped.traverse._3._Right) fun i
-      For a b c d e f g h i ->
-        For a b c d e f g <$>
-        (_Wrapped.traverse._3._Right) fun h <*>
-        (traverse._4._Wrapped.traverse._3._Right) fun i
-      ClassDef a b c d e f g ->
-        ClassDef a b c d e f <$> (_Wrapped.traverse._3._Right) fun g
+      Fundef idnt a ws1 b ws2 c ws3 ws4 nl sts ->
+        Fundef idnt a ws1 b ws2 c ws3 ws4 nl <$> _Statements fun sts
+      If idnt a ws1 b ws3 nl sts sts' ->
+        If idnt a ws1 b ws3 nl <$>
+        _Statements fun sts <*>
+        (traverse._5._Statements) fun sts'
+      While idnt a ws1 b ws3 nl sts ->
+        While idnt a ws1 b ws3 nl <$> _Statements fun sts
+      TryExcept idnt a b c d e f g h ->
+        TryExcept idnt a b c d <$> _Statements fun e <*>
+        (traverse._6._Statements) fun f <*>
+        (traverse._5._Statements) fun g <*>
+        (traverse._5._Statements) fun h
+      TryFinally idnt a b c d e idnt2 f g h i ->
+        TryFinally idnt a b c d <$> _Statements fun e <*> pure idnt2 <*>
+        pure f <*> pure g <*> pure h <*> _Statements fun i
+      For idnt a b c d e f g h i ->
+        For idnt a b c d e f g <$>
+        _Statements fun h <*>
+        (traverse._5._Statements) fun i
+      ClassDef idnt a b c d e f g ->
+        ClassDef idnt a b c d e f <$> _Statements fun g
 
 instance HasExprs Statement where
-  _Exprs f (SmallStatements s ss a b) =
-    SmallStatements <$>
+  _Exprs f (SmallStatements idnt s ss a b) =
+    SmallStatements idnt <$>
     _Exprs f s <*>
     (traverse._2._Exprs) f ss <*>
     pure a <*>
@@ -288,7 +299,8 @@ data ExceptAs v a
 data CompoundStatement (v :: [*]) a
   -- ^ 'def' <spaces> <ident> '(' <spaces> stuff ')' <spaces> ':' <spaces> <newline>
   --   <block>
-  = Fundef a
+  = Fundef
+      (Indents a) a
       (NonEmpty Whitespace) (Ident v a)
       [Whitespace] (CommaSep (Param v a))
       [Whitespace] [Whitespace] Newline
@@ -298,38 +310,44 @@ data CompoundStatement (v :: [*]) a
   --   [ 'else' <spaces> ':' <spaces> <newline>
   --     <block>
   --   ]
-  | If a
+  | If
+      (Indents a) a
       [Whitespace] (Expr v a) [Whitespace] Newline
       (Block v a)
-      (Maybe ([Whitespace], [Whitespace], Newline, Block v a))
+      (Maybe (Indents a, [Whitespace], [Whitespace], Newline, Block v a))
   -- ^ 'if' <spaces> <expr> ':' <spaces> <newline>
   --   <block>
-  | While a
+  | While
+      (Indents a) a
       [Whitespace] (Expr v a) [Whitespace] Newline
       (Block v a)
   -- ^ 'try' <spaces> ':' <spaces> <newline> <block>
   --   ( 'except' <spaces> exceptAs ':' <spaces> <newline> <block> )+
   --   [ 'else' <spaces> ':' <spaces> <newline> <block> ]
   --   [ 'finally' <spaces> ':' <spaces> <newline> <block> ]
-  | TryExcept a
+  | TryExcept
+      (Indents a) a
       [Whitespace] [Whitespace] Newline (Block v a)
-      (NonEmpty ([Whitespace], ExceptAs v a, [Whitespace], Newline, Block v a))
-      (Maybe ([Whitespace], [Whitespace], Newline, Block v a))
-      (Maybe ([Whitespace], [Whitespace], Newline, Block v a))
+      (NonEmpty (Indents a, [Whitespace], ExceptAs v a, [Whitespace], Newline, Block v a))
+      (Maybe (Indents a, [Whitespace], [Whitespace], Newline, Block v a))
+      (Maybe (Indents a, [Whitespace], [Whitespace], Newline, Block v a))
   -- ^ 'try' <spaces> ':' <spaces> <newline> <block>
   --   'finally' <spaces> ':' <spaces> <newline> <block>
-  | TryFinally a
+  | TryFinally
+      (Indents a) a
       [Whitespace] [Whitespace] Newline (Block v a)
-      [Whitespace] [Whitespace] Newline (Block v a)
+      (Indents a) [Whitespace] [Whitespace] Newline (Block v a)
   -- ^ 'for' <spaces> expr 'in' <spaces> expr ':' <spaces> <newline> <block>
   --   [ 'else' <spaces> ':' <spaces> <newline> <block> ]
-  | For a
+  | For
+      (Indents a) a
       [Whitespace] (Expr v a) [Whitespace] (Expr v a) [Whitespace] Newline
       (Block v a)
-      (Maybe ([Whitespace], [Whitespace], Newline, Block v a))
+      (Maybe (Indents a, [Whitespace], [Whitespace], Newline, Block v a))
   -- ^ 'class' <spaces> ident [ '(' <spaces> [ args ] ')' <spaces>] ':' <spaces> <newline>
   --   <block>
-  | ClassDef a
+  | ClassDef
+      (Indents a) a
       (NonEmpty Whitespace) (Ident v a)
       (Maybe ([Whitespace], Maybe (CommaSep1 (Arg v a)), [Whitespace])) [Whitespace] Newline
       (Block v a)
@@ -339,44 +357,44 @@ instance HasExprs ExceptAs where
   _Exprs f (ExceptAs ann e a) = ExceptAs ann <$> f e <*> pure (coerce a)
 
 instance HasExprs Block where
-  _Exprs = _Wrapped.traverse._3._Right._Exprs
+  _Exprs = _Wrapped.traverse._Right._Exprs
 
 instance HasExprs CompoundStatement where
-  _Exprs f (Fundef a ws1 name ws2 params ws3 ws4 nl sts) =
-    Fundef a ws1 (coerce name) ws2 <$>
+  _Exprs f (Fundef idnt a ws1 name ws2 params ws3 ws4 nl sts) =
+    Fundef idnt a ws1 (coerce name) ws2 <$>
     (traverse._Exprs) f params <*>
     pure ws3 <*>
     pure ws4 <*>
     pure nl <*>
-    (_Wrapped.traverse._3._Right._Exprs) f sts
-  _Exprs f (If a ws1 e ws3 nl sts sts') =
-    If a ws1 <$>
+    _Exprs f sts
+  _Exprs f (If idnt a ws1 e ws3 nl sts sts') =
+    If idnt a ws1 <$>
     f e <*>
     pure ws3 <*>
     pure nl <*>
     _Exprs f sts <*>
-    (traverse._4._Exprs) f sts'
-  _Exprs f (While a ws1 e ws3 nl sts) =
-    While a ws1 <$>
+    (traverse._5._Exprs) f sts'
+  _Exprs f (While idnt a ws1 e ws3 nl sts) =
+    While idnt a ws1 <$>
     f e <*>
     pure ws3 <*>
     pure nl <*>
     _Exprs f sts
-  _Exprs fun (TryExcept a b c d e f g h) =
-    TryExcept a b c d <$> _Exprs fun e <*>
+  _Exprs fun (TryExcept idnt a b c d e f g h) =
+    TryExcept idnt a b c d <$> _Exprs fun e <*>
     -- (coerce f) downcasts the ExceptAs
-    (traverse._5._Exprs) fun (coerce f) <*>
-    (traverse._4._Exprs) fun g <*>
-    (traverse._4._Exprs) fun h
-  _Exprs fun (TryFinally a b c d e f g h i) =
-    TryFinally a b c d <$> _Exprs fun e <*>
+    (traverse._6._Exprs) fun (coerce f) <*>
+    (traverse._5._Exprs) fun g <*>
+    (traverse._5._Exprs) fun h
+  _Exprs fun (TryFinally idnt a b c d e idnt2 f g h i) =
+    TryFinally idnt a b c d <$> _Exprs fun e <*> pure idnt2 <*>
     pure f <*> pure g <*> pure h <*> _Exprs fun i
-  _Exprs fun (For a b c d e f g h i) =
-    For a b <$> fun c <*> pure d <*> fun e <*>
+  _Exprs fun (For idnt a b c d e f g h i) =
+    For idnt a b <$> fun c <*> pure d <*> fun e <*>
     pure f <*> pure g <*> _Exprs fun h <*>
-    (traverse._4._Exprs) fun i
-  _Exprs fun (ClassDef a b c d e f g) =
-    ClassDef a b (coerce c) <$>
+    (traverse._5._Exprs) fun i
+  _Exprs fun (ClassDef idnt a b c d e f g) =
+    ClassDef idnt a b (coerce c) <$>
     (traverse._2.traverse.traverse._Exprs) fun d <*> pure e <*> pure f <*>
     _Exprs fun g
 

--- a/src/Language/Python/Internal/Syntax/Statement.hs
+++ b/src/Language/Python/Internal/Syntax/Statement.hs
@@ -77,7 +77,7 @@ newtype Block v a
   { unBlock
     :: NonEmpty
          ( a
-         , [Whitespace]
+         , Indent
          , Either
              (Maybe Comment, Newline)
              (Statement v a)

--- a/src/Language/Python/Internal/Syntax/Statement.hs
+++ b/src/Language/Python/Internal/Syntax/Statement.hs
@@ -173,6 +173,9 @@ data ImportAs e v a
   = ImportAs a (e a) (Maybe (NonEmpty Whitespace, Ident v a))
   deriving (Eq, Show, Functor, Foldable, Traversable)
 
+importAsAnn :: ImportAs e v a -> a
+importAsAnn (ImportAs a _ _) = a
+
 instance Token (e a) (e' a) => Token (ImportAs e v a) (ImportAs e' '[] a) where
   unvalidate (ImportAs x a b) = ImportAs x (unvalidate a) (over (mapped._2) unvalidate b)
 

--- a/src/Language/Python/Internal/Syntax/Statement.hs
+++ b/src/Language/Python/Internal/Syntax/Statement.hs
@@ -7,7 +7,6 @@
 {-# language UndecidableInstances #-}
 module Language.Python.Internal.Syntax.Statement where
 
-import Control.Lens.Fold (foldMapOf, folded)
 import Control.Lens.Getter ((^.), getting)
 import Control.Lens.Lens (Lens, Lens', lens)
 import Control.Lens.Plated (Plated(..), gplate)
@@ -15,11 +14,8 @@ import Control.Lens.Prism (_Just, _Right)
 import Control.Lens.Setter ((.~), over, mapped)
 import Control.Lens.TH (makeLenses, makeWrapped)
 import Control.Lens.Traversal (Traversal, traverseOf)
-import Control.Lens.Tuple (_1, _2, _5, _6)
+import Control.Lens.Tuple (_2, _5, _6)
 import Control.Lens.Wrapped (_Wrapped)
-import Data.Bifunctor (bimap)
-import Data.Bifoldable (bifoldMap)
-import Data.Bitraversable (bitraverse)
 import Data.Coerce (coerce)
 import Data.Function ((&))
 import Data.List.NonEmpty (NonEmpty)
@@ -81,19 +77,9 @@ newtype Block v a
   { unBlock
     :: NonEmpty
          (Either
-            (Indents a, Maybe Comment, Newline)
+            ([Whitespace], Maybe Comment, Newline)
             (Statement v a))
-  } deriving (Eq, Show)
-
-instance Functor (Block v) where
-  fmap f (Block b) = Block $ fmap (bimap (over (_1.mapped) f) (fmap f)) b
-
-instance Foldable (Block v) where
-  foldMap f (Block b) = foldMap (bifoldMap (foldMapOf (_1.folded) f) (foldMap f)) b
-
-instance Traversable (Block v) where
-  traverse f (Block b) =
-    Block <$> traverse (bitraverse (traverseOf (_1.traverse) f) (traverse f)) b
+  } deriving (Eq, Show, Functor, Foldable, Traversable)
 
 class HasBlocks s where
   _Blocks :: Traversal (s v a) (s '[] a) (Block v a) (Block '[] a)

--- a/src/Language/Python/Internal/Syntax/Statement.hs
+++ b/src/Language/Python/Internal/Syntax/Statement.hs
@@ -122,8 +122,9 @@ data Statement (v :: [*]) a
       (SmallStatement v a)
       [([Whitespace], SmallStatement v a)]
       (Maybe [Whitespace])
-      Newline
-  | CompoundStatement (CompoundStatement v a)
+      (Maybe Newline)
+  | CompoundStatement
+      (CompoundStatement v a)
   deriving (Eq, Show, Functor, Foldable, Traversable)
 
 instance HasBlocks Statement where

--- a/src/Language/Python/Internal/Syntax/Statement.hs
+++ b/src/Language/Python/Internal/Syntax/Statement.hs
@@ -232,7 +232,7 @@ instance Token (ImportTargets v a) (ImportTargets '[] a) where
 data SmallStatement (v :: [*]) a
   = Return a [Whitespace] (Expr v a)
   | Expr a (Expr v a)
-  | Assign a (Expr v a) [Whitespace] [Whitespace] (Expr v a)
+  | Assign a (Expr v a) [Whitespace] (Expr v a)
   | Pass a
   | Break a
   | Continue a
@@ -264,7 +264,7 @@ instance HasExprs SmallStatement where
       x
   _Exprs f (Return a ws e) = Return a ws <$> f e
   _Exprs f (Expr a e) = Expr a <$> f e
-  _Exprs f (Assign a e1 ws1 ws2 e2) = Assign a <$> f e1 <*> pure ws1 <*> pure ws2 <*> f e2
+  _Exprs f (Assign a e1 ws2 e2) = Assign a <$> f e1 <*> pure ws2 <*> f e2
   _Exprs _ p@Pass{} = pure $ coerce p
   _Exprs _ p@Break{} = pure $ coerce p
   _Exprs _ p@Continue{} = pure $ coerce p

--- a/src/Language/Python/Internal/Syntax/Whitespace.hs
+++ b/src/Language/Python/Internal/Syntax/Whitespace.hs
@@ -1,4 +1,20 @@
-module Language.Python.Internal.Syntax.Whitespace where
+{-# language GeneralizedNewtypeDeriving, MultiParamTypeClasses, BangPatterns #-}
+{-# language TypeFamilies #-}
+module Language.Python.Internal.Syntax.Whitespace
+  ( Newline(..)
+  , Whitespace(..)
+  , IndentLevel, getIndentLevel, indentLevel, absoluteIndentLevel
+  , Indent(..), indentWhitespaces
+  )
+where
+
+import Control.Lens.Iso (Iso', iso, from)
+import Control.Lens.Getter (view)
+import Data.Foldable (toList)
+import Data.FingerTree (FingerTree, Measured(..), fromList)
+import Data.Monoid (Monoid, Endo(..), Dual(..))
+import Data.Semigroup (Semigroup)
+import GHC.Exts (IsList(..))
 
 data Newline
   = CR
@@ -12,3 +28,48 @@ data Whitespace
   | Continued Newline [Whitespace]
   | Newline Newline
   deriving (Eq, Show)
+
+newtype IndentLevel
+  = IndentLevel
+  { appIndentLevel
+    :: Maybe Int -> Dual (Endo (Bool, Int))
+  }
+  deriving Monoid
+
+indentLevel :: Indent -> Int
+indentLevel = getIndentLevel . measure . unIndent
+
+getIndentLevel :: IndentLevel -> Int
+getIndentLevel il =
+  snd $
+  appEndo (getDual (appIndentLevel il Nothing)) (False, 0)
+
+absoluteIndentLevel :: Int -> Indent -> Int
+absoluteIndentLevel n il =
+  snd $
+  appEndo (getDual (appIndentLevel (measure $ unIndent il) $ Just n)) (False, 0)
+
+instance Measured IndentLevel Whitespace where
+  measure e =
+    IndentLevel $
+    \absolute -> Dual . Endo $
+    \(b, !i) ->
+    case e of
+      Space -> (b, if b then i else i+1)
+      Tab -> (b, if b then i else maybe (i + 8 - rem i 8) (+i) absolute)
+      Continued{} -> (True, i)
+      Newline{} -> error "Newline does not have an IndentLevel"
+
+newtype Indent
+  = MkIndent
+  { unIndent :: FingerTree IndentLevel Whitespace
+  } deriving (Eq, Show, Semigroup, Monoid)
+
+instance IsList Indent where
+  type Item Indent = Whitespace
+  toList = view indentWhitespaces
+  fromList = view $ from indentWhitespaces
+
+indentWhitespaces :: Iso' Indent [Whitespace]
+indentWhitespaces =
+  iso (Data.Foldable.toList . unIndent) (MkIndent . Data.FingerTree.fromList)

--- a/src/Language/Python/Internal/Syntax/Whitespace.hs
+++ b/src/Language/Python/Internal/Syntax/Whitespace.hs
@@ -1,16 +1,20 @@
 {-# language GeneralizedNewtypeDeriving, MultiParamTypeClasses, BangPatterns #-}
 {-# language TypeFamilies #-}
+{-# language DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
+{-# language TemplateHaskell #-}
 module Language.Python.Internal.Syntax.Whitespace
   ( Newline(..)
   , Whitespace(..)
   , lastWhitespace
   , IndentLevel, getIndentLevel, indentLevel, absoluteIndentLevel
   , Indent(..), indentWhitespaces
+  , Indents(..), indentsValue, indentsAnn
   )
 where
 
 import Control.Lens.Iso (Iso', iso, from)
 import Control.Lens.Getter (view)
+import Control.Lens.TH (makeLenses)
 import Data.Foldable (toList)
 import Data.FingerTree (FingerTree, Measured(..), fromList)
 import Data.Monoid (Monoid, Endo(..), Dual(..))
@@ -85,3 +89,11 @@ instance IsList Indent where
 indentWhitespaces :: Iso' Indent [Whitespace]
 indentWhitespaces =
   iso (Data.Foldable.toList . unIndent) (MkIndent . Data.FingerTree.fromList)
+
+data Indents a
+  = Indents
+  { _indentsValue :: [Indent]
+  , _indentsAnn :: a
+  } deriving (Eq, Show, Functor, Foldable, Traversable)
+
+makeLenses ''Indents

--- a/src/Language/Python/Internal/Syntax/Whitespace.hs
+++ b/src/Language/Python/Internal/Syntax/Whitespace.hs
@@ -1,10 +1,19 @@
 module Language.Python.Internal.Syntax.Whitespace where
 
+import Data.Functor (($>))
+import Control.Applicative ((<|>))
+import Text.Trifecta (CharParsing, char)
+
 data Newline
   = CR
   | LF
   | CRLF
   deriving (Eq, Show)
+
+newline :: CharParsing m => m Newline
+newline =
+  char '\n' $> LF <|>
+  char '\r' *> (char '\n' $> CRLF <|> pure CR)
 
 data Whitespace
   = Space

--- a/src/Language/Python/Internal/Syntax/Whitespace.hs
+++ b/src/Language/Python/Internal/Syntax/Whitespace.hs
@@ -1,19 +1,10 @@
 module Language.Python.Internal.Syntax.Whitespace where
 
-import Data.Functor (($>))
-import Control.Applicative ((<|>))
-import Text.Trifecta (CharParsing, char)
-
 data Newline
   = CR
   | LF
   | CRLF
   deriving (Eq, Show)
-
-newline :: CharParsing m => m Newline
-newline =
-  char '\n' $> LF <|>
-  char '\r' *> (char '\n' $> CRLF <|> pure CR)
 
 data Whitespace
   = Space

--- a/src/Language/Python/Internal/Syntax/Whitespace.hs
+++ b/src/Language/Python/Internal/Syntax/Whitespace.hs
@@ -3,6 +3,7 @@
 module Language.Python.Internal.Syntax.Whitespace
   ( Newline(..)
   , Whitespace(..)
+  , lastWhitespace
   , IndentLevel, getIndentLevel, indentLevel, absoluteIndentLevel
   , Indent(..), indentWhitespaces
   )
@@ -28,6 +29,17 @@ data Whitespace
   | Continued Newline [Whitespace]
   | Newline Newline
   deriving (Eq, Show)
+
+lastWhitespace :: [Whitespace] -> Maybe Whitespace
+lastWhitespace [] = Nothing
+lastWhitespace (w : ws) =
+  case ws of
+    [] ->
+      case w of
+        Continued nl [] -> Just $ Newline nl
+        Continued _ ws' -> lastWhitespace ws'
+        _ -> Just w
+    _ -> lastWhitespace ws
 
 newtype IndentLevel
   = IndentLevel

--- a/src/Language/Python/Syntax.hs
+++ b/src/Language/Python/Syntax.hs
@@ -167,7 +167,7 @@ longStr_ :: String -> Expr '[] ()
 longStr_ s = String () Nothing LongDouble s []
 
 (.=) :: Expr '[] () -> Expr '[] () -> Statement '[] ()
-(.=) a b = SmallStatements (Assign () a [Space] [Space] b) [] Nothing (Just LF)
+(.=) a b = SmallStatements (Assign () (a & whitespaceAfter .~ [Space]) [Space] b) [] Nothing (Just LF)
 
 forElse_
   :: Expr '[] ()

--- a/src/Language/Python/Syntax.hs
+++ b/src/Language/Python/Syntax.hs
@@ -37,10 +37,10 @@ call_ :: Expr '[] () -> [Arg '[] ()] -> Expr '[] ()
 call_ expr args = Call () expr [] (listToCommaSep args) []
 
 return_ :: Expr '[] () -> Statement '[] ()
-return_ e = SmallStatements (Return () [Space] e) [] Nothing LF
+return_ e = SmallStatements (Return () [Space] e) [] Nothing (Just LF)
 
 expr_ :: Expr '[] () -> Statement '[] ()
-expr_ e = SmallStatements (Expr () e) [] Nothing LF
+expr_ e = SmallStatements (Expr () e) [] Nothing (Just LF)
 
 list_ :: [Expr '[] ()] -> Expr '[] ()
 list_ es = List () [] (listToCommaSep es) []
@@ -143,10 +143,10 @@ none_ :: Expr '[] ()
 none_ = None () []
 
 pass_ :: Statement '[] ()
-pass_ = SmallStatements (Pass ()) [] Nothing LF
+pass_ = SmallStatements (Pass ()) [] Nothing (Just LF)
 
 break_ :: Statement '[] ()
-break_ = SmallStatements (Break ()) [] Nothing LF
+break_ = SmallStatements (Break ()) [] Nothing (Just LF)
 
 true_ :: Expr '[] ()
 true_ = Bool () True []
@@ -167,7 +167,7 @@ longStr_ :: String -> Expr '[] ()
 longStr_ s = String () Nothing LongDouble s []
 
 (.=) :: Expr '[] () -> Expr '[] () -> Statement '[] ()
-(.=) a b = SmallStatements (Assign () a [Space] [Space] b) [] Nothing LF
+(.=) a b = SmallStatements (Assign () a [Space] [Space] b) [] Nothing (Just LF)
 
 forElse_
   :: Expr '[] ()

--- a/src/Language/Python/Syntax.hs
+++ b/src/Language/Python/Syntax.hs
@@ -43,7 +43,7 @@ expr_ :: Expr '[] () -> Statement '[] ()
 expr_ e = SmallStatements (Expr () e) [] Nothing (Just LF)
 
 list_ :: [Expr '[] ()] -> Expr '[] ()
-list_ es = List () [] (listToCommaSep es) []
+list_ es = List () [] (listToCommaSep1' es) []
 
 is_ :: Expr '[] () -> Expr '[] () -> Expr '[] ()
 is_ a = BinOp () (a & whitespaceAfter .~ [Space]) (Is () [Space])

--- a/src/Language/Python/Validate/Indentation.hs
+++ b/src/Language/Python/Validate/Indentation.hs
@@ -1,20 +1,87 @@
 {-# language DataKinds #-}
 {-# language TypeOperators #-}
+{-# language GeneralizedNewtypeDeriving #-}
 module Language.Python.Validate.Indentation where
 
-import Control.Applicative
-import Control.Lens ((#), _Wrapped, view, over, from, _2, _4, traverseOf, _Right)
+import Control.Lens ((#), _Wrapped, over, _2, traverseOf, _Right)
 import Control.Lens.Getter ((^.))
-import Data.Coerce
+import Control.Monad.State (State, get, put)
+import Data.Bitraversable (bitraverse)
+import Data.Coerce (coerce)
+import Data.Foldable (fold)
+import Data.Functor.Compose (Compose(..))
+import Data.List.NonEmpty (NonEmpty(..))
 import Data.Type.Set
 import Data.Validate
-
-import qualified Data.List.NonEmpty as NonEmpty
 
 import Language.Python.Internal.Syntax
 import Language.Python.Validate.Indentation.Error
 
 data Indentation
+
+-- | "The next line must be..."
+data NextIndent
+  = GreaterThan
+  | EqualTo
+  | LessThan
+  deriving (Eq, Show)
+
+newtype ValidateIndentation e a
+  = ValidateIndentation
+  { unValidateIndentation :: Compose (State (NextIndent, [Indent])) (Validate [e]) a
+  } deriving (Functor, Applicative)
+
+withNextIndent
+  :: (NextIndent -> [Indent] -> ValidateIndentation e a)
+  -> ValidateIndentation e a
+withNextIndent f =
+  ValidateIndentation . Compose $
+    get >>= getCompose . unValidateIndentation . uncurry f
+
+indentationError :: [e] -> ValidateIndentation e a
+indentationError = ValidateIndentation . Compose . pure . Failure
+
+checkIndent :: AsIndentationError e v a => Indents a -> ValidateIndentation e (Indents a)
+checkIndent i =
+  withNextIndent $ \ni i' ->
+  let
+    a = i ^. indentsAnn
+    ii = fold (i ^. indentsValue)
+    ii' = fold i'
+    absolute1Comparison = compare (absoluteIndentLevel 1 ii') (absoluteIndentLevel 1 ii)
+    absolute8Comparison = compare (absoluteIndentLevel 8 ii') (absoluteIndentLevel 8 ii)
+  in
+    case ni of
+      GreaterThan ->
+        case (absolute1Comparison, absolute8Comparison) of
+          (GT, GT) -> pure i
+          (GT, _) -> indentationError [_TabError # a]
+          (_, GT) -> indentationError [_TabError # a]
+          (EQ, EQ) -> indentationError [_ExpectedIndent # a]
+          (_, EQ) -> indentationError [_TabError # a]
+          (EQ, _) -> indentationError [_TabError # a]
+          (LT, LT) -> indentationError [_ExpectedIndent # a]
+      EqualTo ->
+        case (absolute1Comparison, absolute8Comparison) of
+          (EQ, EQ) -> pure i
+          (EQ, _) -> indentationError [_TabError # a]
+          (_, EQ) -> indentationError [_TabError # a]
+          (GT, GT) -> indentationError [_ExpectedLevel # (i', a)]
+          (_, GT) -> indentationError [_TabError # a]
+          (GT, _) -> indentationError [_TabError # a]
+          (LT, LT) -> indentationError [_ExpectedLevel # (i', a)]
+      LessThan ->
+        case (absolute1Comparison, absolute8Comparison) of
+          (LT, LT) -> pure i
+          (LT, _) -> indentationError [_TabError # a]
+          (_, LT) -> indentationError [_TabError # a]
+          (EQ, EQ) -> indentationError [_ExpectedDedent # a]
+          (_, EQ) -> indentationError [_TabError # a]
+          (EQ, _) -> indentationError [_TabError # a]
+          (GT, GT) -> indentationError [_ExpectedDedent # a]
+
+setNextIndent :: NextIndent -> [Indent] -> ValidateIndentation e ()
+setNextIndent ni is = ValidateIndentation . Compose $ pure () <$ put (ni, is)
 
 equivalentIndentation :: [Whitespace] -> [Whitespace] -> Bool
 equivalentIndentation [] [] = True
@@ -36,50 +103,40 @@ equivalentIndentation (x:xs) (y:ys) =
 validateBlockIndentation
   :: AsIndentationError e v a
   => Block v a
-  -> Validate [e] (Block (Nub (Indentation ': v)) a)
-validateBlockIndentation a =
-  view (from _Wrapped) . NonEmpty.fromList <$>
-  go Nothing (NonEmpty.toList $ view _Wrapped a)
+  -> ValidateIndentation e (Block (Nub (Indentation ': v)) a)
+validateBlockIndentation (Block (b :| bs)) =
+  withNextIndent $ \ni is ->
+  fmap Block $
+  (:|) <$>
+  bitraverse pure validateStatementIndentation b <*>
+  traverse (commentOrStatement is) bs
   where
-    go _ [] = pure []
-    go a ((ann, ws, Left c):xs) = ((ann, ws, Left c) :) <$> go a xs
-    go a ((ann, ws, Right st):xs)
-      | null $ ws ^. indentWhitespaces = Failure [_ExpectedIndent # ann] <*> go a xs
-      | otherwise =
-          case a of
-            Nothing ->
-              liftA2 (:)
-                ((,,) ann ws . Right <$> validateStatementIndentation st)
-                (go (Just ws) xs)
-            Just ws'
-              | equivalentIndentation (ws ^. indentWhitespaces) (ws' ^. indentWhitespaces) ->
-                  liftA2 (:)
-                    ((,,) ann ws . Right <$> validateStatementIndentation st)
-                    (go a xs)
-              | otherwise -> Failure [_WrongIndent # (ws', ws, ann)] <*> go a xs
+    commentOrStatement _ (Left (a, b, c)) = pure $ Left (a, b, c)
+    commentOrStatement is (Right st) =
+      Right <$ setNextIndent EqualTo is <*> validateStatementIndentation st
 
 validateExprIndentation
   :: AsIndentationError e v a
   => Expr v a
-  -> Validate [e] (Expr (Nub (Indentation ': v)) a)
+  -> ValidateIndentation e (Expr (Nub (Indentation ': v)) a)
 validateExprIndentation e = pure $ coerce e
 
 validateParamsIndentation
   :: AsIndentationError e v a
   => CommaSep (Param v a)
-  -> Validate [e] (CommaSep (Param (Nub (Indentation ': v)) a))
+  -> ValidateIndentation e (CommaSep (Param (Nub (Indentation ': v)) a))
 validateParamsIndentation e = pure $ coerce e
 
 validateArgsIndentation
   :: AsIndentationError e v a
   => CommaSep (Arg v a)
-  -> Validate [e] (CommaSep (Arg (Nub (Indentation ': v)) a))
+  -> ValidateIndentation e (CommaSep (Arg (Nub (Indentation ': v)) a))
 validateArgsIndentation e = pure $ coerce e
 
 validateExceptAsIndentation
   :: AsIndentationError e v a
   => ExceptAs v a
-  -> Validate [e] (ExceptAs (Nub (Indentation ': v)) a)
+  -> ValidateIndentation e (ExceptAs (Nub (Indentation ': v)) a)
 validateExceptAsIndentation (ExceptAs ann e f) =
   ExceptAs ann <$>
   validateExprIndentation e <*>
@@ -88,58 +145,99 @@ validateExceptAsIndentation (ExceptAs ann e f) =
 validateCompoundStatementIndentation
   :: AsIndentationError e v a
   => CompoundStatement v a
-  -> Validate [e] (CompoundStatement (Nub (Indentation ': v)) a)
-validateCompoundStatementIndentation (Fundef a ws1 name ws2 params ws3 ws4 nl body) =
-  Fundef a ws1 (coerce name) ws2 <$>
-  validateParamsIndentation params <*>
-  pure ws3 <*>
-  pure ws4 <*>
-  pure nl <*>
+  -> ValidateIndentation e (CompoundStatement (Nub (Indentation ': v)) a)
+validateCompoundStatementIndentation (Fundef idnt a ws1 name ws2 params ws3 ws4 nl body) =
+  (\idnt' params' body' -> Fundef idnt' a ws1 (coerce name) ws2 params' ws3 ws4 nl body') <$>
+  checkIndent idnt <*>
+  validateParamsIndentation params <*
+  setNextIndent GreaterThan (idnt ^. indentsValue) <*>
   validateBlockIndentation body
-validateCompoundStatementIndentation (If a ws1 expr ws3 nl body body') =
-  If a ws1 <$>
-  validateExprIndentation expr <*>
-  pure ws3 <*>
-  pure nl <*>
+validateCompoundStatementIndentation (If idnt a ws1 expr ws3 nl body body1) =
+  (\idnt' expr' body' body1' -> If idnt' a ws1 expr' ws3 nl body' body1') <$>
+  checkIndent idnt <*>
+  validateExprIndentation expr <*
+  setNextIndent GreaterThan (idnt ^. indentsValue) <*>
   validateBlockIndentation body <*>
-  traverseOf (traverse._4) validateBlockIndentation body'
-validateCompoundStatementIndentation (While a ws1 expr ws3 nl body) =
-  While a ws1 <$>
-  validateExprIndentation expr <*>
-  pure ws3 <*>
-  pure nl <*>
+  traverse
+    (\(idnt2, a, b, c, d) ->
+       (\idnt2' -> (,,,,) idnt2' a b c) <$
+       setNextIndent EqualTo (idnt ^. indentsValue) <*>
+       checkIndent idnt2 <*>
+       validateBlockIndentation d)
+    body1
+validateCompoundStatementIndentation (While idnt a ws1 expr ws3 nl body) =
+  (\idnt' expr' body' -> While idnt' a ws1 expr' ws3 nl body') <$>
+  checkIndent idnt <*>
+  validateExprIndentation expr <*
+  setNextIndent GreaterThan (idnt ^. indentsValue) <*>
   validateBlockIndentation body
-validateCompoundStatementIndentation (TryExcept a b c d e f k l) =
-  TryExcept a b c d <$>
+validateCompoundStatementIndentation (TryExcept idnt a b c d e f k l) =
+  (\idnt' -> TryExcept idnt' a b c d) <$>
+  checkIndent idnt <*
+  setNextIndent GreaterThan (idnt ^. indentsValue) <*>
   validateBlockIndentation e <*>
   traverse
-    (\(a, b, c, d, e) ->
-       (,,,,) a <$>
-       validateExceptAsIndentation b <*>
-       pure c <*>
-       pure d <*>
-       validateBlockIndentation e)
-    f <*>
-  traverseOf (traverse._4) validateBlockIndentation k <*>
-  traverseOf (traverse._4) validateBlockIndentation l
-validateCompoundStatementIndentation (TryFinally a b c d e f g h i) =
-  TryFinally a b c d <$>
-  validateBlockIndentation e <*>
-  pure f <*> pure g <*> pure h <*>
+    (\(a, b, c, d, e, f) ->
+       (\a' c' -> (,,,,,) a' b c' d e) <$
+       setNextIndent EqualTo (idnt ^. indentsValue) <*>
+       checkIndent a <*>
+       validateExceptAsIndentation c <*
+       setNextIndent GreaterThan (idnt ^. indentsValue) <*>
+       validateBlockIndentation f)
+    f <*
+  setNextIndent EqualTo (idnt ^. indentsValue) <*>
+  traverse
+    (\(idnt2, a, b, c, d) ->
+       (\idnt2' -> (,,,,) idnt2' a b c) <$
+       setNextIndent EqualTo (idnt ^. indentsValue) <*>
+       checkIndent idnt2 <*
+       setNextIndent GreaterThan (idnt ^. indentsValue) <*>
+       validateBlockIndentation d)
+    k <*
+  setNextIndent EqualTo (idnt ^. indentsValue) <*>
+  traverse
+    (\(idnt2, a, b, c, d) ->
+       (\idnt2' -> (,,,,) idnt2' a b c) <$
+       setNextIndent EqualTo (idnt ^. indentsValue) <*>
+       checkIndent idnt2 <*
+       setNextIndent GreaterThan (idnt ^. indentsValue) <*>
+       validateBlockIndentation d)
+    l
+validateCompoundStatementIndentation (TryFinally idnt a b c d e idnt2 f g h i) =
+  (\idnt' e' idnt2' -> TryFinally idnt' a b c d e' idnt2' f g h) <$>
+  checkIndent idnt <*
+  setNextIndent GreaterThan (idnt ^. indentsValue) <*>
+  validateBlockIndentation e <*
+  setNextIndent EqualTo (idnt ^. indentsValue) <*>
+  checkIndent idnt2 <*
+  setNextIndent GreaterThan (idnt ^. indentsValue) <*>
   validateBlockIndentation i
-validateCompoundStatementIndentation (For a b c d e f g h i) =
-  For a b <$>
-  validateExprIndentation c <*> pure d <*>
-  validateExprIndentation e <*> pure f <*> pure g <*>
-  validateBlockIndentation h <*>
-  traverseOf (traverse._4) validateBlockIndentation i
-validateCompoundStatementIndentation (ClassDef a b c d e f g) =
-  ClassDef a b (coerce c) (coerce d) e f <$> validateBlockIndentation g
+validateCompoundStatementIndentation (For idnt a b c d e f g h i) =
+  (\idnt' c' e' -> For idnt' a b c' d e' f g) <$>
+  checkIndent idnt <*>
+  validateExprIndentation c <*>
+  validateExprIndentation e <*
+  setNextIndent GreaterThan (idnt ^. indentsValue) <*>
+  validateBlockIndentation h <*
+  setNextIndent EqualTo (idnt ^. indentsValue) <*>
+  traverse
+    (\(idnt2, a, b, c, d) ->
+       (\idnt2' -> (,,,,) idnt2' a b c) <$
+       setNextIndent EqualTo (idnt ^. indentsValue) <*>
+       checkIndent idnt2 <*
+       setNextIndent GreaterThan (idnt ^. indentsValue) <*>
+       validateBlockIndentation d)
+    i
+validateCompoundStatementIndentation (ClassDef idnt a b c d e f g) =
+  (\idnt' -> ClassDef idnt' a b (coerce c) (coerce d) e f) <$>
+  checkIndent idnt <*
+  setNextIndent GreaterThan (idnt ^. indentsValue) <*>
+  validateBlockIndentation g
 
 validateStatementIndentation
   :: AsIndentationError e v a
   => Statement v a
-  -> Validate [e] (Statement (Nub (Indentation ': v)) a)
+  -> ValidateIndentation e (Statement (Nub (Indentation ': v)) a)
 validateStatementIndentation (CompoundStatement c) =
   CompoundStatement <$> validateCompoundStatementIndentation c
 validateStatementIndentation s@SmallStatements{} = pure $ coerce s
@@ -147,6 +245,6 @@ validateStatementIndentation s@SmallStatements{} = pure $ coerce s
 validateModuleIndentation
   :: AsIndentationError e v a
   => Module v a
-  -> Validate [e] (Module (Nub (Indentation ': v)) a)
+  -> ValidateIndentation e (Module (Nub (Indentation ': v)) a)
 validateModuleIndentation =
   traverseOf (_Wrapped.traverse._Right) validateStatementIndentation

--- a/src/Language/Python/Validate/Indentation/Error.hs
+++ b/src/Language/Python/Validate/Indentation/Error.hs
@@ -8,7 +8,10 @@ import Control.Lens.TH
 
 data IndentationError (v :: [*]) a
   = WrongIndent Indent Indent a
+  | TabError a
   | ExpectedIndent a
+  | ExpectedDedent a
+  | ExpectedLevel [Indent] a
   deriving (Eq, Show)
 
 makeClassyPrisms ''IndentationError

--- a/src/Language/Python/Validate/Indentation/Error.hs
+++ b/src/Language/Python/Validate/Indentation/Error.hs
@@ -7,7 +7,7 @@ import Language.Python.Internal.Syntax
 import Control.Lens.TH
 
 data IndentationError (v :: [*]) a
-  = WrongIndent [Whitespace] [Whitespace] a
+  = WrongIndent Indent Indent a
   | ExpectedIndent a
   deriving (Eq, Show)
 

--- a/src/Language/Python/Validate/Indentation/Error.hs
+++ b/src/Language/Python/Validate/Indentation/Error.hs
@@ -9,9 +9,9 @@ import Control.Lens.TH
 data IndentationError (v :: [*]) a
   = WrongIndent Indent Indent a
   | TabError a
-  | ExpectedIndent a
+  | ExpectedGreaterThan [Indent] (Indents a)
   | ExpectedDedent a
-  | ExpectedLevel [Indent] a
+  | ExpectedEqualTo [Indent] (Indents a)
   deriving (Eq, Show)
 
 makeClassyPrisms ''IndentationError

--- a/src/Language/Python/Validate/Indentation/Error.hs
+++ b/src/Language/Python/Validate/Indentation/Error.hs
@@ -10,7 +10,6 @@ data IndentationError (v :: [*]) a
   = WrongIndent Indent Indent a
   | TabError a
   | ExpectedGreaterThan [Indent] (Indents a)
-  | ExpectedDedent a
   | ExpectedEqualTo [Indent] (Indents a)
   deriving (Eq, Show)
 

--- a/src/Language/Python/Validate/Scope.hs
+++ b/src/Language/Python/Validate/Scope.hs
@@ -255,11 +255,11 @@ validateSmallStatementScope (Raise a ws f) =
     f
 validateSmallStatementScope (Return a ws e) = Return a ws <$> validateExprScope e
 validateSmallStatementScope (Expr a e) = Expr a <$> validateExprScope e
-validateSmallStatementScope (Assign a l ws1 ws2 r) =
+validateSmallStatementScope (Assign a l ws2 r) =
   let
     ls = l ^.. unvalidated.cosmos._Ident._2.to (_identAnnotation &&& _identValue)
   in
-  (Assign a (coerce l) ws1 ws2 <$> validateExprScope r) <*
+  (Assign a (coerce l) ws2 <$> validateExprScope r) <*
   extendScope scLocalScope ls <*
   extendScope scImmediateScope ls
 validateSmallStatementScope (Global a _ _) = scopeErrors [_FoundGlobal # a]

--- a/src/Language/Python/Validate/Scope.hs
+++ b/src/Language/Python/Validate/Scope.hs
@@ -336,7 +336,7 @@ validateExprScope
 validateExprScope (Not a ws e) = Not a ws <$> validateExprScope e
 validateExprScope (List a ws1 es ws2) =
   List a ws1 <$>
-  traverse validateExprScope es <*>
+  traverseOf (traverse.traverse) validateExprScope es <*>
   pure ws2
 validateExprScope (Deref a e ws1 r) =
   Deref a <$>

--- a/src/Language/Python/Validate/Syntax.hs
+++ b/src/Language/Python/Validate/Syntax.hs
@@ -250,11 +250,7 @@ validateBlockSyntax
      )
   => Block v a
   -> ValidateSyntax e (Block (Nub (Syntax ': v)) a)
-validateBlockSyntax (Block bs) = Block . NonEmpty.fromList <$> go (NonEmpty.toList bs)
-  where
-    go [] = error "impossible"
-    go [b] = pure <$> traverseOf (_3._Right) validateStatementSyntax b
-    go (b:bs) = (:) <$> traverseOf (_3._Right) validateStatementSyntax b <*> go bs
+validateBlockSyntax = traverseOf (_Wrapped.traverse._Right) validateStatementSyntax
 
 validateCompoundStatementSyntax
   :: ( AsSyntaxError e v a
@@ -262,11 +258,11 @@ validateCompoundStatementSyntax
      )
   => CompoundStatement v a
   -> ValidateSyntax e (CompoundStatement (Nub (Syntax ': v)) a)
-validateCompoundStatementSyntax (Fundef a ws1 name ws2 params ws3 ws4 nl body) =
+validateCompoundStatementSyntax (Fundef idnts a ws1 name ws2 params ws3 ws4 nl body) =
   let
     paramIdents = params ^.. folded.unvalidated.paramName.identValue
   in
-    Fundef a ws1 <$>
+    Fundef idnts a ws1 <$>
     validateIdent name <*>
     pure ws2 <*>
     validateParamsSyntax params <*>
@@ -285,32 +281,32 @@ validateCompoundStatementSyntax (Fundef a ws1 name ws2 params ws3 ws4 nl body) =
                 Just paramIdents
             })
          (validateBlockSyntax body))
-validateCompoundStatementSyntax (If a ws1 expr ws3 nl body body') =
-  If a <$>
+validateCompoundStatementSyntax (If idnts a ws1 expr ws3 nl body body') =
+  If idnts a <$>
   (validateWhitespace a ws1 <*
    validateAdjacentL a (Keyword ('i' :| "f") ws1, keyword) (expr, renderExpr)) <*>
   validateExprSyntax expr <*>
   validateWhitespace a ws3 <*>
   pure nl <*>
   validateBlockSyntax body <*>
-  traverseOf (traverse._4) validateBlockSyntax body'
-validateCompoundStatementSyntax (While a ws1 expr ws3 nl body) =
-  While a <$>
+  traverseOf (traverse._5) validateBlockSyntax body'
+validateCompoundStatementSyntax (While idnts a ws1 expr ws3 nl body) =
+  While idnts a <$>
   (validateWhitespace a ws1 <*
    validateAdjacentL a (Keyword ('w' :| "hile") ws1, keyword) (expr, renderExpr)) <*>
   validateExprSyntax expr <*>
   validateWhitespace a ws3 <*>
   pure nl <*>
   localSyntaxContext (\ctxt -> ctxt { _inLoop = True}) (validateBlockSyntax body)
-validateCompoundStatementSyntax (TryExcept a b c d e f k l) =
-  TryExcept a <$>
+validateCompoundStatementSyntax (TryExcept idnts a b c d e f k l) =
+  TryExcept idnts a <$>
   validateWhitespace a b <*>
   validateWhitespace a c <*>
   pure d <*>
   validateBlockSyntax e <*>
   traverse
-    (\(f, g, h, i, j) ->
-       (,,,,) <$>
+    (\(idnts, f, g, h, i, j) ->
+       (,,,,,) idnts <$>
        validateWhitespace a f <*
        validateAdjacentR a
          (Keyword ('e' :| "xcept") f, keyword)
@@ -321,25 +317,25 @@ validateCompoundStatementSyntax (TryExcept a b c d e f k l) =
        validateBlockSyntax j)
     f <*>
   traverse
-    (\(x, y, z, w) ->
-       (,,,) <$>
+    (\(idnts, x, y, z, w) ->
+       (,,,,) idnts <$>
        validateWhitespace a x <*> validateWhitespace a y <*>
        pure z <*> validateBlockSyntax w)
     k <*>
   traverse
-    (\(x, y, z, w) ->
-       (,,,) <$>
+    (\(idnts, x, y, z, w) ->
+       (,,,,) idnts <$>
        validateWhitespace a x <*> validateWhitespace a y <*>
        pure z <*> validateBlockSyntax w)
     l
-validateCompoundStatementSyntax (TryFinally a b c d e f g h i) =
-  TryFinally a <$>
+validateCompoundStatementSyntax (TryFinally idnts a b c d e idnts2 f g h i) =
+  TryFinally idnts a <$>
   validateWhitespace a b <*> validateWhitespace a c <*> pure d <*>
-  validateBlockSyntax e <*>
+  validateBlockSyntax e <*> pure idnts2 <*>
   validateWhitespace a f <*> validateWhitespace a g <*> pure h <*>
   validateBlockSyntax i
-validateCompoundStatementSyntax (For a b c d e f g h i) =
-  For a <$>
+validateCompoundStatementSyntax (For idnts a b c d e f g h i) =
+  For idnts a <$>
   validateWhitespace a b <*>
   (validateAdjacentR a (Keyword ('f' :| "or") b, keyword) (c, renderExpr) *>
    if canAssignTo c
@@ -351,15 +347,15 @@ validateCompoundStatementSyntax (For a b c d e f g h i) =
   pure g <*>
   localSyntaxContext (\c -> c { _inLoop = True }) (validateBlockSyntax h) <*>
   traverse
-    (\(x, y, z, w) ->
-       (,,,) <$>
+    (\(idnts, x, y, z, w) ->
+       (,,,,) idnts <$>
        validateWhitespace a x <*>
        validateWhitespace a y <*>
        pure z <*>
        validateBlockSyntax w)
     i
-validateCompoundStatementSyntax (ClassDef a b c d e f g) =
-  ClassDef a <$>
+validateCompoundStatementSyntax (ClassDef idnts a b c d e f g) =
+  ClassDef idnts a <$>
   validateWhitespace a b <*>
   validateIdent c <*>
   traverse
@@ -512,8 +508,8 @@ validateStatementSyntax
   -> ValidateSyntax e (Statement (Nub (Syntax ': v)) a)
 validateStatementSyntax (CompoundStatement c) =
   CompoundStatement <$> validateCompoundStatementSyntax c
-validateStatementSyntax (SmallStatements s ss sc nl) =
-  SmallStatements <$>
+validateStatementSyntax (SmallStatements idnts s ss sc nl) =
+  SmallStatements idnts <$>
   validateSmallStatementSyntax s <*>
   traverseOf (traverse._2) validateSmallStatementSyntax ss <*>
   pure sc <*>

--- a/src/Language/Python/Validate/Syntax.hs
+++ b/src/Language/Python/Validate/Syntax.hs
@@ -209,7 +209,9 @@ validateExprSyntax (String a prefix strType b ws) =
 validateExprSyntax (Int a n ws) = pure $ Int a n ws
 validateExprSyntax (Ident a name) = Ident a <$> validateIdent name
 validateExprSyntax (List a ws1 exprs ws2) =
-  List a ws1 <$> traverse validateExprSyntax exprs <*> pure ws2
+  List a ws1 <$>
+  traverseOf (traverse.traverse) validateExprSyntax exprs <*>
+  pure ws2
 validateExprSyntax (Deref a expr ws1 name) =
   Deref a <$>
   validateExprSyntax expr <*>
@@ -527,7 +529,7 @@ canAssignTo BinOp{} = False
 canAssignTo Bool{} = False
 canAssignTo (Parens _ _ a _) = canAssignTo a
 canAssignTo String{} = False
-canAssignTo (List _ _ a _) = all canAssignTo a
+canAssignTo (List _ _ a _) = all (all canAssignTo) a
 canAssignTo (Tuple _ a _ b) = all canAssignTo $ a : toListOf (folded.folded) b
 canAssignTo _ = True
 

--- a/src/Language/Python/Validate/Syntax.hs
+++ b/src/Language/Python/Validate/Syntax.hs
@@ -452,7 +452,7 @@ validateSmallStatementSyntax (Return a ws expr) =
 validateSmallStatementSyntax (Expr a expr) =
   Expr a <$>
   validateExprSyntax expr
-validateSmallStatementSyntax (Assign a lvalue ws1 ws2 rvalue) =
+validateSmallStatementSyntax (Assign a lvalue ws2 rvalue) =
   syntaxContext `bindValidateSyntax` \sctxt ->
     let
       assigns =
@@ -464,7 +464,6 @@ validateSmallStatementSyntax (Assign a lvalue ws1 ws2 rvalue) =
       (if canAssignTo lvalue
         then validateExprSyntax lvalue
         else syntaxErrors [_CannotAssignTo # (a, lvalue)]) <*>
-      pure ws1 <*>
       pure ws2 <*>
       validateExprSyntax rvalue) <*
       modifyNonlocals (assigns ++)

--- a/test/Generators/Common.hs
+++ b/test/Generators/Common.hs
@@ -17,7 +17,10 @@ whitespaceSize (Continued _ ws) = 1 + sum (fmap whitespaceSize ws)
 whitespaceSize (Newline _) = 1
 
 genSmallInt :: MonadGen m => m (Expr '[] ())
-genSmallInt = Int () <$> Gen.integral (Range.constant 0 100) <*> genWhitespaces
+genSmallInt =
+  Int () <$>
+  Gen.integral (Range.constant 0 100) <*>
+  genWhitespaces
 
 genString :: MonadGen m => m String
 genString = Gen.list (Range.constant 0 50) (Gen.filter (/='\0') Gen.latin1)
@@ -125,8 +128,8 @@ genAnyWhitespaces = do
       , (:) <$> (Newline <$> genNewline) <*> go (n-1)
       ]
 
-genWhitespaces1 :: MonadGen m => m (NonEmpty Whitespace)
-genWhitespaces1 = do
+genAnyWhitespaces1 :: MonadGen m => m (NonEmpty Whitespace)
+genAnyWhitespaces1 = do
   n <- Gen.integral (Range.constant 1 10)
   go n
   where
@@ -143,6 +146,24 @@ genWhitespaces1 = do
       , (Tab `NonEmpty.cons`) <$> go (n-1)
       , fmap pure $ Continued <$> genNewline <*> fmap NonEmpty.toList (go $ n-1)
       , NonEmpty.cons <$> (Newline <$> genNewline) <*> go (n-1)
+      ]
+
+genWhitespaces1 :: MonadGen m => m (NonEmpty Whitespace)
+genWhitespaces1 = do
+  n <- Gen.integral (Range.constant 1 10)
+  go n
+  where
+    go 1 =
+      Gen.choice
+      [ pure $ pure Space
+      , pure $ pure Tab
+      , fmap pure $ Continued <$> genNewline <*> pure []
+      ]
+    go n =
+      Gen.choice
+      [ (Space `NonEmpty.cons`) <$> go (n-1)
+      , (Tab `NonEmpty.cons`) <$> go (n-1)
+      , fmap pure $ Continued <$> genNewline <*> fmap NonEmpty.toList (go $ n-1)
       ]
 
 genNone :: MonadGen m => m (Expr '[] ())

--- a/test/Generators/Common.hs
+++ b/test/Generators/Common.hs
@@ -144,8 +144,16 @@ genAnyWhitespaces1 = do
       Gen.choice
       [ (Space `NonEmpty.cons`) <$> go (n-1)
       , (Tab `NonEmpty.cons`) <$> go (n-1)
-      , fmap pure $ Continued <$> genNewline <*> fmap NonEmpty.toList (go $ n-1)
-      , NonEmpty.cons <$> (Newline <$> genNewline) <*> go (n-1)
+      , fmap pure $
+        Continued <$>
+        genNewline <*>
+        ((:) <$>
+         Gen.choice
+           [ pure Space
+           , pure Tab
+           , Newline <$> genNewline
+           ] <*>
+         (NonEmpty.toList <$> go (n-1)))
       ]
 
 genWhitespaces1 :: MonadGen m => m (NonEmpty Whitespace)
@@ -163,7 +171,16 @@ genWhitespaces1 = do
       Gen.choice
       [ (Space `NonEmpty.cons`) <$> go (n-1)
       , (Tab `NonEmpty.cons`) <$> go (n-1)
-      , fmap pure $ Continued <$> genNewline <*> fmap NonEmpty.toList (go $ n-1)
+      , fmap pure $
+        Continued <$>
+        genNewline <*>
+        ((:) <$>
+         Gen.choice
+           [ pure Space
+           , pure Tab
+           , Newline <$> genNewline
+           ] <*>
+         (NonEmpty.toList <$> go (n-1)))
       ]
 
 genNone :: MonadGen m => m (Expr '[] ())

--- a/test/Generators/Common.hs
+++ b/test/Generators/Common.hs
@@ -178,7 +178,6 @@ genWhitespaces1 = do
          Gen.choice
            [ pure Space
            , pure Tab
-           , Newline <$> genNewline
            ] <*>
          (NonEmpty.toList <$> go (n-1)))
       ]

--- a/test/Generators/Common.hs
+++ b/test/Generators/Common.hs
@@ -235,14 +235,3 @@ genSizedCommaSep1' ma = Gen.sized $ \n ->
             (Gen.resize (n - n') $ genSizedCommaSep1' ma)
             (\b -> CommaSepMany1' a <$> genWhitespaces <*> pure b)
       ]
-
-genImportAs :: MonadGen m => m (e ()) -> m (Ident '[] ()) -> m (ImportAs e '[] ())
-genImportAs me genIdent =
-  Gen.sized $ \n -> do
-    n' <- Gen.integral (Range.constant 1 n)
-    let n'' = n - n'
-    ImportAs () <$>
-      Gen.resize n' me <*>
-      (if n'' <= 2
-       then pure Nothing
-       else fmap Just $ (,) <$> genWhitespaces1 <*> Gen.resize n'' genIdent)

--- a/test/Generators/Common.hs
+++ b/test/Generators/Common.hs
@@ -158,28 +158,15 @@ genAnyWhitespaces1 = do
 
 genWhitespaces1 :: MonadGen m => m (NonEmpty Whitespace)
 genWhitespaces1 = do
-  n <- Gen.integral (Range.constant 1 10)
-  go n
+  n <- Gen.integral (Range.constant 0 9)
+  (:|) <$> Gen.element [Space, Tab] <*> genWhitespaces
   where
-    go 1 =
-      Gen.choice
-      [ pure $ pure Space
-      , pure $ pure Tab
-      , fmap pure $ Continued <$> genNewline <*> pure []
-      ]
+    go 0 = pure []
     go n =
       Gen.choice
-      [ (Space `NonEmpty.cons`) <$> go (n-1)
-      , (Tab `NonEmpty.cons`) <$> go (n-1)
-      , fmap pure $
-        Continued <$>
-        genNewline <*>
-        ((:) <$>
-         Gen.choice
-           [ pure Space
-           , pure Tab
-           ] <*>
-         (NonEmpty.toList <$> go (n-1)))
+      [ (Space :) <$> go (n-1)
+      , (Tab :) <$> go (n-1)
+      , fmap pure $ Continued <$> genNewline <*> go (n-1)
       ]
 
 genNone :: MonadGen m => m (Expr '[] ())

--- a/test/Generators/Correct.hs
+++ b/test/Generators/Correct.hs
@@ -8,6 +8,7 @@ import Control.Applicative
 import Control.Lens.Cons (_last)
 import Control.Lens.Fold
 import Control.Lens.Getter
+import Control.Lens.Iso (from)
 import Control.Lens.Plated
 import Control.Lens.Prism (_Just)
 import Control.Lens.Setter
@@ -119,7 +120,7 @@ genInt = Int () <$> Gen.integral (Range.constant 0 (2^32)) <*> genWhitespaces
 
 genBlock :: (MonadGen m, MonadState GenState m) => m (Block '[] ())
 genBlock = do
-  indent <- NonEmpty.toList <$> genWhitespaces1
+  indent <- view (from indentWhitespaces) . NonEmpty.toList <$> genWhitespaces1
   go False indent
   where
     go b indent =

--- a/test/Generators/Correct.hs
+++ b/test/Generators/Correct.hs
@@ -321,7 +321,7 @@ genSmallStatement = Gen.sized $ \n -> do
             when (isJust isInFunction) $
               willBeNonlocals %= ((a ^.. cosmos._Ident._2.identValue) ++)
             b <- Gen.resize (n - n') genExpr
-            Assign () a <$> genWhitespaces <*> genWhitespaces <*> pure b
+            Assign () a <$> genWhitespaces <*> pure b
         , Gen.sized $ \n -> do
             n' <- Gen.integral (Range.constant 2 (n-1))
             Global () <$>

--- a/test/Generators/Correct.hs
+++ b/test/Generators/Correct.hs
@@ -530,12 +530,13 @@ genStatement
 genStatement =
   Gen.sized $ \n ->
   if n < 4
-  then
+  then do
+    (ws, nl) <- whitespaceAndNewline
     SmallStatements <$>
-    localState genSmallStatement <*>
-    pure [] <*>
-    Gen.maybe genWhitespaces <*>
-    (Just <$> genNewline)
+      localState genSmallStatement <*>
+      pure [] <*>
+      Gen.maybe (pure ws) <*>
+      pure (Just nl)
   else
     Gen.scale (subtract 1) $
     Gen.choice

--- a/test/Generators/Correct.hs
+++ b/test/Generators/Correct.hs
@@ -508,7 +508,7 @@ genStatement =
     localState genSmallStatement <*>
     pure [] <*>
     Gen.maybe genWhitespaces <*>
-    genNewline
+    (Just <$> genNewline)
   else
     Gen.scale (subtract 1) $
     Gen.choice
@@ -526,5 +526,5 @@ genStatement =
                (Gen.resize ((n-n') `div` n'') $
                 (,) <$> genWhitespaces <*> localState genSmallStatement)) <*>
           Gen.maybe genWhitespaces <*>
-          genNewline
+          (Just <$> genNewline)
     ]

--- a/test/Generators/Correct.hs
+++ b/test/Generators/Correct.hs
@@ -609,3 +609,14 @@ genStatement =
           Gen.maybe genWhitespaces <*>
           (Just <$> genNewline)
     ]
+
+genImportAs :: (Token (e ()) (e ()), MonadGen m) => m (e ()) -> m (Ident '[] ()) -> m (ImportAs e '[] ())
+genImportAs me genIdent =
+  Gen.sized $ \n -> do
+    n' <- Gen.integral (Range.constant 1 n)
+    let n'' = n - n'
+    ImportAs () <$>
+      set (mapped.whitespaceAfter) [Space] (Gen.resize n' me) <*>
+      (if n'' <= 2
+       then pure Nothing
+       else fmap Just $ (,) <$> genWhitespaces1 <*> Gen.resize n'' genIdent)

--- a/test/Generators/Correct.hs
+++ b/test/Generators/Correct.hs
@@ -227,11 +227,11 @@ genList :: MonadGen m => m (Expr '[] ()) -> m (Expr '[] ())
 genList genExpr' =
   Gen.shrink
     (\case
-        List _ _ (CommaSepOne e) _ -> [e]
+        List _ _ (Just (CommaSepOne1' e _)) _ -> [e]
         _ -> []) $
   List () <$>
   genWhitespaces <*>
-  genSizedCommaSep genExpr' <*>
+  Gen.maybe (genSizedCommaSep1' genExpr') <*>
   genWhitespaces
 
 genParens :: MonadGen m => m (Expr '[] ()) -> m (Expr '[] ())

--- a/test/Generators/Correct.hs
+++ b/test/Generators/Correct.hs
@@ -56,7 +56,7 @@ localState m = do
 
 genIdent :: MonadGen m => m (Ident '[] ())
 genIdent =
-  Gen.filter (\i -> _identValue i `notElem` reservedWords) $
+  Gen.filter (\i -> not $ any (`isPrefixOf` _identValue i) reservedWords) $
   MkIdent () <$>
   liftA2 (:)
     (Gen.choice [Gen.alpha, pure '_'])
@@ -77,8 +77,7 @@ genRelativeModuleName :: MonadGen m => m (RelativeModuleName '[] ())
 genRelativeModuleName =
   Gen.choice
   [ Relative <$>
-    Gen.nonEmpty (Range.constant 1 10) genDot <*>
-    genWhitespaces
+    Gen.nonEmpty (Range.constant 1 10) genDot
   , RelativeWithName <$>
     Gen.list (Range.constant 1 10) genDot <*>
     genModuleName

--- a/test/Generators/General.hs
+++ b/test/Generators/General.hs
@@ -145,7 +145,7 @@ genExpr' isExp = Gen.sized $ \n ->
     Gen.choice $
       [ List () <$>
         genWhitespaces <*>
-        genSizedCommaSep genExpr <*>
+        Gen.maybe (genSizedCommaSep1' genExpr) <*>
         genWhitespaces
       , Gen.subtermM
           genExpr

--- a/test/Generators/General.hs
+++ b/test/Generators/General.hs
@@ -384,6 +384,6 @@ genModule = Gen.sized $ \n -> do
       (Gen.resize
          (n `div` num)
          (Gen.choice
-          [ fmap Left $ (,,) <$> genWhitespaces <*> Gen.maybe genComment <*> genNewline
+          [ fmap Left $ (,,) <$> genWhitespaces <*> Gen.maybe genComment <*> Gen.maybe genNewline
           , Right <$> genStatement
           ]))

--- a/test/Generators/General.hs
+++ b/test/Generators/General.hs
@@ -6,6 +6,7 @@ import Control.Applicative
 import Control.Lens.Cons
 import Control.Lens.Fold
 import Control.Lens.Getter
+import Control.Lens.Iso (from)
 import Control.Lens.Wrapped
 import Data.Foldable (toList)
 import Data.List.NonEmpty (NonEmpty(..))
@@ -87,7 +88,7 @@ genImportTargets =
 genBlock :: MonadGen m => m (Block '[] ())
 genBlock =
   Gen.shrink ((++) <$> shrinkHead <*> shrinkTail) $ do
-  indent <- NonEmpty.toList <$> genWhitespaces1
+  indent <- view (from indentWhitespaces) . NonEmpty.toList <$> genWhitespaces1
   go indent
   where
     shrinkHead b

--- a/test/Generators/General.hs
+++ b/test/Generators/General.hs
@@ -354,7 +354,7 @@ genStatement =
     genSmallStatement <*>
     pure [] <*>
     Gen.maybe genWhitespaces <*>
-    genNewline
+    (Gen.maybe genNewline)
   else
     Gen.scale (subtract 1) $
     Gen.choice
@@ -371,7 +371,7 @@ genStatement =
                (Gen.resize ((n-n') `div` n'') $
                 (,) <$> genWhitespaces <*> genSmallStatement)) <*>
           Gen.maybe genWhitespaces <*>
-          genNewline
+          (Gen.maybe genNewline)
     , CompoundStatement <$> genCompoundStatement
     ]
 

--- a/test/Generators/General.hs
+++ b/test/Generators/General.hs
@@ -106,20 +106,20 @@ genBlock =
           s1 <-
             Gen.choice
               [ Right <$> genStatement
-              , fmap Left $ (,) <$> Gen.maybe genComment <*> genNewline
+              , fmap Left $ (,,) <$> genWhitespaces <*> Gen.maybe genComment <*> genNewline
               ]
-          pure . Block $ ((), indent, s1) :| []
+          pure . Block $ s1 :| []
         else do
           n' <- Gen.integral (Range.constant 1 (n-1))
           s1 <-
             Gen.resize n' $
             Gen.choice
               [ Right <$> genStatement
-              , fmap Left $ (,) <$> Gen.maybe genComment <*> genNewline
+              , fmap Left $ (,,) <$> genWhitespaces <*> Gen.maybe genComment <*> genNewline
               ]
           let n'' = n - n'
           b <- Gen.resize n'' (go indent)
-          pure . Block $ NonEmpty.cons ((), indent, s1) (unBlock b)
+          pure . Block $ NonEmpty.cons s1 (unBlock b)
 
 -- | This is necessary to prevent generating exponentials that will take forever to evaluate
 -- when python does constant folding
@@ -237,7 +237,8 @@ genCompoundStatement =
         a <- Gen.resize n' $ genSizedCommaSep (genParam genExpr)
         let paramIdents = a ^.. folded.paramName.identValue
         b <- Gen.resize (n - n') genBlock
-        Fundef () <$> genWhitespaces1 <*> genIdent <*> genWhitespaces <*> pure a <*>
+        Fundef <$> genIndents <*> pure () <*>
+          genWhitespaces1 <*> genIdent <*> genWhitespaces <*> pure a <*>
           genWhitespaces <*> genWhitespaces <*> genNewline <*> pure b
     , Gen.sized $ \n -> do
         n' <- Gen.integral (Range.constant 1 (n-1))
@@ -249,18 +250,22 @@ genCompoundStatement =
           then pure Nothing
           else
             fmap Just $
-            (,,,) <$>
+            (,,,,) <$>
+            genIndents <*>
             genWhitespaces <*>
             genWhitespaces <*>
             genNewline <*>
             Gen.resize (n - n' - n'') genBlock
-        If () <$> genWhitespaces <*> pure a <*>
+        If <$> genIndents <*>
+          pure () <*> genWhitespaces <*> pure a <*>
           genWhitespaces <*> genNewline <*> pure b <*> pure c
     , Gen.sized $ \n -> do
         n' <- Gen.integral (Range.constant 1 (n-1))
         a <- Gen.resize n' genExpr
         b <- Gen.resize (n - n') genBlock
-        While () <$> genWhitespaces <*> pure a <*>
+        While <$>
+          genIndents <*>
+          pure () <*> genWhitespaces <*> pure a <*>
           genWhitespaces <*> genNewline <*> pure b
     , Gen.sized $ \n -> do
         sz <- Gen.integral (Range.constant 1 5)
@@ -276,20 +281,33 @@ genCompoundStatement =
             e2 <- Gen.maybe (Gen.resize (remaining - n4) genBlock)
             (,) <$>
               fmap Just
-                ((,,,) <$> genWhitespaces <*> genWhitespaces <*> genNewline <*> pure e1) <*>
+                ((,,,,) <$>
+                 genIndents <*>
+                 genWhitespaces <*>
+                 genWhitespaces <*>
+                 genNewline <*>
+                 pure e1) <*>
               maybe
                  (pure Nothing)
                  (\e2' ->
                     fmap Just $
-                    (,,,) <$> genWhitespaces <*> genWhitespaces <*> genNewline <*> pure e2')
+                    (,,,,) <$>
+                    genIndents <*>
+                    genWhitespaces <*>
+                    genWhitespaces <*>
+                    genNewline <*>
+                    pure e2')
                  e2
           else pure (Nothing, Nothing)
-        TryExcept () <$>
+        TryExcept <$>
+          genIndents <*>
+          pure () <*>
           genWhitespaces <*> genWhitespaces <*> genNewline <*>
           Gen.resize n1 genBlock <*>
           Gen.nonEmpty
             (Range.singleton sz)
-            ((,,,,) <$>
+            ((,,,,,) <$>
+             genIndents <*>
              genWhitespaces <*>
              (ExceptAs () <$>
               Gen.resize n2 genExpr <*>
@@ -302,14 +320,19 @@ genCompoundStatement =
     , Gen.sized $ \n -> do
         n1 <- Gen.integral (Range.constant 1 $ n-1)
         n2 <- Gen.integral (Range.constant 1 n1)
-        TryFinally () <$>
+        TryFinally <$>
+          genIndents <*>
+          pure () <*>
           genWhitespaces <*> genWhitespaces <*> genNewline <*>
           Gen.resize n1 genBlock <*>
+          genIndents <*>
           genWhitespaces <*> genWhitespaces <*> genNewline <*>
           Gen.resize n2 genBlock
     , Gen.sized $ \n -> do
         n1 <- Gen.integral $ Range.constant 0 (n-1)
-        ClassDef () <$>
+        ClassDef <$>
+          genIndents <*>
+          pure () <*>
           genWhitespaces1 <*>
           genIdent <*>
           Gen.maybe
@@ -327,7 +350,9 @@ genCompoundStatement =
         n2 <- Gen.integral $ Range.constant 1 (max 1 $ n-n1-1)
         n3 <- Gen.integral $ Range.constant 1 (max 1 $ n-n1-n2)
         n4 <- Gen.integral $ Range.constant 0 (max 0 $ n-n1-n2-n3)
-        For () <$>
+        For <$>
+          genIndents <*>
+          pure () <*>
           genWhitespaces <*>
           Gen.resize n1 genExpr <*>
           genWhitespaces <*>
@@ -339,7 +364,8 @@ genCompoundStatement =
           else
             Gen.resize n4
               (fmap Just $
-               (,,,) <$>
+               (,,,,) <$>
+               genIndents <*>
                genWhitespaces <*> genWhitespaces <*>
                genNewline <*> genBlock)
     | n >= 4
@@ -351,6 +377,7 @@ genStatement =
   if n < 4
   then
     SmallStatements <$>
+    genIndents <*>
     genSmallStatement <*>
     pure [] <*>
     Gen.maybe genWhitespaces <*>
@@ -362,6 +389,7 @@ genStatement =
         n' <- Gen.integral (Range.constant 1 n)
         n'' <- Gen.integral (Range.constant 0 (n-n'))
         SmallStatements <$>
+          genIndents <*>
           Gen.resize n' genSmallStatement <*>
           (if n'' == 0
            then pure []
@@ -375,6 +403,13 @@ genStatement =
     , CompoundStatement <$> genCompoundStatement
     ]
 
+genIndent :: MonadGen m => m Indent
+genIndent =
+  view (from indentWhitespaces) <$> genWhitespaces
+
+genIndents :: MonadGen m => m (Indents ())
+genIndents = (\is -> Indents is ()) <$> Gen.list (Range.constant 0 10) genIndent
+
 genModule :: MonadGen m => m (Module '[] ())
 genModule = Gen.sized $ \n -> do
   num <- Gen.integral (Range.constant 1 n)
@@ -384,6 +419,6 @@ genModule = Gen.sized $ \n -> do
       (Gen.resize
          (n `div` num)
          (Gen.choice
-          [ fmap Left $ (,,) <$> genWhitespaces <*> Gen.maybe genComment <*> Gen.maybe genNewline
+          [ fmap Left $ (,,) <$> genIndents <*> Gen.maybe genComment <*> Gen.maybe genNewline
           , Right <$> genStatement
           ]))

--- a/test/Generators/General.hs
+++ b/test/Generators/General.hs
@@ -66,8 +66,7 @@ genRelativeModuleName :: MonadGen m => m (RelativeModuleName '[] ())
 genRelativeModuleName =
   Gen.choice
   [ Relative <$>
-    Gen.nonEmpty (Range.constant 1 10) genDot <*>
-    genWhitespaces
+    Gen.nonEmpty (Range.constant 1 10) genDot
   , RelativeWithName <$>
     Gen.list (Range.constant 1 10) genDot <*>
     genModuleName

--- a/test/Generators/General.hs
+++ b/test/Generators/General.hs
@@ -191,7 +191,7 @@ genSmallStatement = Gen.sized $ \n ->
             n' <- Gen.integral (Range.constant 1 (n-1))
             a <- Gen.resize n' genExpr
             b <- Gen.resize (n - n') genExpr
-            Assign () a <$> genWhitespaces <*> genWhitespaces <*> pure b
+            Assign () a <$> genWhitespaces <*> pure b
         , Gen.sized $ \n -> do
             n' <- Gen.integral (Range.constant 2 (n-1))
             Global () <$>

--- a/test/Generators/General.hs
+++ b/test/Generators/General.hs
@@ -422,3 +422,14 @@ genModule = Gen.sized $ \n -> do
           [ fmap Left $ (,,) <$> genIndents <*> Gen.maybe genComment <*> Gen.maybe genNewline
           , Right <$> genStatement
           ]))
+
+genImportAs :: MonadGen m => m (e ()) -> m (Ident '[] ()) -> m (ImportAs e '[] ())
+genImportAs me genIdent =
+  Gen.sized $ \n -> do
+    n' <- Gen.integral (Range.constant 1 n)
+    let n'' = n - n'
+    ImportAs () <$>
+      Gen.resize n' me <*>
+      (if n'' <= 2
+       then pure Nothing
+       else fmap Just $ (,) <$> genWhitespaces1 <*> Gen.resize n'' genIdent)

--- a/test/Helpers.hs
+++ b/test/Helpers.hs
@@ -18,7 +18,7 @@ doTokenize str = do
       failure
     Trifecta.Success a -> pure a
 
-doIndentation :: Monad m => [LogicalLine a] -> PropertyT m [IndentedLine a]
+doIndentation :: (Show a, Monad m) => [LogicalLine a] -> PropertyT m [IndentedLine a]
 doIndentation lls = do
   let res = indentation lls
   case res of

--- a/test/Helpers.hs
+++ b/test/Helpers.hs
@@ -1,0 +1,54 @@
+module Helpers where
+
+import Control.Monad ((<=<))
+import qualified Text.Trifecta as Trifecta
+
+import Hedgehog
+
+import Language.Python.Internal.Lexer
+  (PyToken, LogicalLine, IndentedLine, Nested, tokenize, logicalLines, indentation, nested)
+import Language.Python.Internal.Parse (Parser, runParser)
+
+doTokenize :: Monad m => String -> PropertyT m [PyToken Trifecta.Caret]
+doTokenize str = do
+  let res = tokenize str
+  case res of
+    Trifecta.Failure err -> do
+      annotateShow err
+      failure
+    Trifecta.Success a -> pure a
+
+doIndentation :: Monad m => [LogicalLine a] -> PropertyT m [IndentedLine a]
+doIndentation lls = do
+  let res = indentation lls
+  case res of
+    Left err -> do
+      annotateShow err
+      failure
+    Right a -> pure a
+
+doNested :: Monad m => [IndentedLine a] -> PropertyT m (Nested a)
+doNested ils = do
+  let res = nested ils
+  case res of
+    Left err -> do
+      annotateShow err
+      failure
+    Right a -> pure a
+
+doParse :: (Show ann, Monad m) => Parser ann a -> Nested ann -> PropertyT m a
+doParse pa input = do
+  let res = runParser pa input
+  case res of
+    Left err -> do
+      annotateShow err
+      failure
+    Right a -> pure a
+
+doToPython :: Monad m => Parser Trifecta.Caret a -> String -> PropertyT m a
+doToPython pa =
+  doParse pa <=<
+  doNested <=<
+  doIndentation <=<
+  pure . logicalLines <=<
+  doTokenize

--- a/test/LexerParser.hs
+++ b/test/LexerParser.hs
@@ -19,6 +19,7 @@ lexerParserTests =
   , ("Test parse 2", test_parse_2)
   , ("Test full trip 1", test_fulltrip_1)
   , ("Test full trip 2", test_fulltrip_2)
+  , ("Test full trip 3", test_fulltrip_3)
   ]
 
 test_fulltrip_1 :: Property
@@ -34,6 +35,13 @@ test_fulltrip_2 =
     let str = "(   1\n       *\n  3\n    )"
     a <- doToPython (expr space) str
     renderExpr a === str
+
+test_fulltrip_3 :: Property
+test_fulltrip_3 =
+  withTests 1 . property $ do
+    let str = "pass;"
+    a <- doToPython statement str
+    renderLines (renderStatement a) === str
 
 parseTab :: Parser ann Whitespace
 parseTab = do

--- a/test/LexerParser.hs
+++ b/test/LexerParser.hs
@@ -3,13 +3,14 @@ module LexerParser (lexerParserTests) where
 
 import Data.Functor.Alt ((<!>))
 import qualified Data.Functor.Alt as Alt (many)
-import qualified Text.Trifecta as Trifecta
 import Hedgehog
 
 import Language.Python.Internal.Lexer
 import Language.Python.Internal.Parse
 import Language.Python.Internal.Render
 import Language.Python.Internal.Syntax.Whitespace
+
+import Helpers (doToPython, doParse, doNested)
 
 lexerParserTests :: Group
 lexerParserTests =
@@ -19,69 +20,21 @@ lexerParserTests =
   , ("Test full trip 1", test_fulltrip_1)
   ]
 
-doTokenize :: Monad m => String -> PropertyT m [PyToken Trifecta.Caret]
-doTokenize str = do
-  let res = tokenize str
-  case res of
-    Trifecta.Failure err -> do
-      annotateShow err
-      failure
-    Trifecta.Success a -> pure a
-
-doIndentation :: Monad m => [LogicalLine a] -> PropertyT m [IndentedLine a]
-doIndentation lls = do
-  let res = indentation lls
-  case res of
-    Left err -> do
-      annotateShow err
-      failure
-    Right a -> pure a
-
-doNested :: Monad m => [IndentedLine a] -> PropertyT m (Nested a)
-doNested ils = do
-  let res = nested ils
-  case res of
-    Left err -> do
-      annotateShow err
-      failure
-    Right a -> pure a
-
-doParse :: (Show ann, Monad m) => Parser' ann a -> Nested ann -> PropertyT m a
-doParse pa input = do
-  let res = runParser pa input
-  case res of
-    Left err -> do
-      annotateShow err
-      failure
-    Right a -> pure a
-
 test_fulltrip_1 :: Property
 test_fulltrip_1 =
   withTests 1 . property $ do
-    let str = "def a():\n   return 2 + 3"
-    tks <- doTokenize str
-    length tks === 17
-
-    let ll = logicalLines tks
-    length ll === 2
-
-    indents <- doIndentation ll
-    length indents === 4
-
-    nested <- doNested indents
-    annotateShow nested
-
-    a <- doParse statement' nested
+    let str = "def a(x, y=2, *z, **w):\n   return 2 + 3"
+    a <- doToPython statement str
     renderLines (renderStatement a) === str
 
-parseTab :: Parser' ann Whitespace
+parseTab :: Parser ann Whitespace
 parseTab = do
   curTk <- currentToken
   case curTk of
     TkTab{} -> pure Tab
     _ -> parseError $ ExpectedToken (TkTab ()) curTk
 
-parseSpace :: Parser' ann Whitespace
+parseSpace :: Parser ann Whitespace
 parseSpace = do
   curTk <- currentToken
   case curTk of

--- a/test/LexerParser.hs
+++ b/test/LexerParser.hs
@@ -28,6 +28,7 @@ lexerParserTests =
   , ("Test full trip 9", test_fulltrip_9)
   , ("Test full trip 10", test_fulltrip_10)
   , ("Test full trip 11", test_fulltrip_11)
+  , ("Test full trip 12", test_fulltrip_12)
   ]
 
 test_fulltrip_1 :: Property
@@ -226,6 +227,38 @@ test_fulltrip_11 =
         , "else:"
         , " \tpass"
         , " \tpass"
+        ]
+
+    tks <- doTokenize str
+    annotateShow $! tks
+
+    let lls = logicalLines tks
+    annotateShow $! lls
+
+    ils <- doIndentation lls
+    annotateShow $! ils
+
+    nst <- doNested ils
+    annotateShow $! nst
+
+    a <- doParse module_ nst
+    annotateShow $! a
+
+    renderModule a === str
+
+test_fulltrip_12 :: Property
+test_fulltrip_12 =
+  withTests 1 . property $ do
+    let
+      str =
+        unlines
+        [ "try:"
+        , " \tpass"
+        , " \tdef a():"
+        , " \t pass"
+        , " \tpass"
+        , "finally:"
+        , " pass"
         ]
 
     tks <- doTokenize str

--- a/test/LexerParser.hs
+++ b/test/LexerParser.hs
@@ -21,6 +21,7 @@ lexerParserTests =
   , ("Test full trip 2", test_fulltrip_2)
   , ("Test full trip 3", test_fulltrip_3)
   , ("Test full trip 4", test_fulltrip_4)
+  , ("Test full trip 5", test_fulltrip_5)
   ]
 
 test_fulltrip_1 :: Property
@@ -54,6 +55,27 @@ test_fulltrip_4 =
 
     let lls = logicalLines tks
     length lls === 4
+    annotateShow lls
+
+    ils <- doIndentation lls
+    annotateShow ils
+
+    nst <- doNested ils
+    annotateShow nst
+
+    a <- doToPython statement str
+    renderLines (renderStatement a) === str
+
+test_fulltrip_5 :: Property
+test_fulltrip_5 =
+  withTests 1 . property $ do
+    let str = "if False:\n pass\n pass\nelse:\n pass\n pass\n"
+
+    tks <- doTokenize str
+    annotateShow tks
+
+    let lls = logicalLines tks
+    length lls === 6
     annotateShow lls
 
     ils <- doIndentation lls

--- a/test/LexerParser.hs
+++ b/test/LexerParser.hs
@@ -10,7 +10,7 @@ import Language.Python.Internal.Parse
 import Language.Python.Internal.Render
 import Language.Python.Internal.Syntax.Whitespace
 
-import Helpers (doToPython, doParse, doNested)
+import Helpers (doToPython, doParse, doNested, doTokenize, doIndentation)
 
 lexerParserTests :: Group
 lexerParserTests =
@@ -20,6 +20,7 @@ lexerParserTests =
   , ("Test full trip 1", test_fulltrip_1)
   , ("Test full trip 2", test_fulltrip_2)
   , ("Test full trip 3", test_fulltrip_3)
+  , ("Test full trip 4", test_fulltrip_4)
   ]
 
 test_fulltrip_1 :: Property
@@ -40,6 +41,27 @@ test_fulltrip_3 :: Property
 test_fulltrip_3 =
   withTests 1 . property $ do
     let str = "pass;"
+    a <- doToPython statement str
+    renderLines (renderStatement a) === str
+
+test_fulltrip_4 :: Property
+test_fulltrip_4 =
+  withTests 1 . property $ do
+    let str = "def a():\n pass\n #\n pass\n"
+
+    tks <- doTokenize str
+    annotateShow tks
+
+    let lls = logicalLines tks
+    length lls === 4
+    annotateShow lls
+
+    ils <- doIndentation lls
+    annotateShow ils
+
+    nst <- doNested ils
+    annotateShow nst
+
     a <- doToPython statement str
     renderLines (renderStatement a) === str
 

--- a/test/LexerParser.hs
+++ b/test/LexerParser.hs
@@ -26,6 +26,8 @@ lexerParserTests =
   , ("Test full trip 7", test_fulltrip_7)
   , ("Test full trip 8", test_fulltrip_8)
   , ("Test full trip 9", test_fulltrip_9)
+  , ("Test full trip 10", test_fulltrip_10)
+  , ("Test full trip 11", test_fulltrip_11)
   ]
 
 test_fulltrip_1 :: Property
@@ -173,6 +175,75 @@ test_fulltrip_9 =
 
     a <- doParse module_ nst
     annotateShow a
+
+    renderModule a === str
+
+test_fulltrip_10 :: Property
+test_fulltrip_10 =
+  withTests 1 . property $ do
+    let
+      str =
+        unlines
+        [ "from blah import  boo"
+        , "import baz   as wop"
+        , ""
+        , "def thing():"
+        , "    pass"
+        , ""
+        , "def    hello():"
+        , "    what; up;"
+        , ""
+        , "def boo(a, *b, c=1, **d):"
+        , "    pass"
+        ]
+
+    tks <- doTokenize str
+    annotateShow $! tks
+
+    let lls = logicalLines tks
+    annotateShow $! lls
+
+    ils <- doIndentation lls
+    annotateShow $! ils
+
+
+    nst <- doNested ils
+    annotateShow $! nst
+
+    a <- doParse module_ nst
+    annotateShow $! a
+
+    renderModule a === str
+
+test_fulltrip_11 :: Property
+test_fulltrip_11 =
+  withTests 1 . property $ do
+    let
+      str =
+        unlines
+        [ "if False:"
+        , " pass"
+        , " pass"
+        , "else:"
+        , " \tpass"
+        , " \tpass"
+        ]
+
+    tks <- doTokenize str
+    annotateShow $! tks
+
+    let lls = logicalLines tks
+    annotateShow $! lls
+
+    ils <- doIndentation lls
+    annotateShow $! ils
+
+
+    nst <- doNested ils
+    annotateShow $! nst
+
+    a <- doParse module_ nst
+    annotateShow $! a
 
     renderModule a === str
 

--- a/test/LexerParser.hs
+++ b/test/LexerParser.hs
@@ -1,0 +1,130 @@
+{-# language OverloadedStrings #-}
+module LexerParser (lexerParserTests) where
+
+import Data.Functor.Alt ((<!>))
+import qualified Data.Functor.Alt as Alt (many)
+import qualified Text.Trifecta as Trifecta
+import Hedgehog
+
+import Language.Python.Internal.Lexer
+import Language.Python.Internal.Parse
+import Language.Python.Internal.Render
+import Language.Python.Internal.Syntax.Whitespace
+
+lexerParserTests :: Group
+lexerParserTests =
+  Group "Lexer/Parser tests"
+  [ ("Test parse 1", test_parse_1)
+  , ("Test parse 2", test_parse_2)
+  , ("Test full trip 1", test_fulltrip_1)
+  ]
+
+doTokenize :: Monad m => String -> PropertyT m [PyToken Trifecta.Caret]
+doTokenize str = do
+  let res = tokenize str
+  case res of
+    Trifecta.Failure err -> do
+      annotateShow err
+      failure
+    Trifecta.Success a -> pure a
+
+doIndentation :: Monad m => [LogicalLine a] -> PropertyT m [IndentedLine a]
+doIndentation lls = do
+  let res = indentation lls
+  case res of
+    Left err -> do
+      annotateShow err
+      failure
+    Right a -> pure a
+
+doNested :: Monad m => [IndentedLine a] -> PropertyT m (Nested a)
+doNested ils = do
+  let res = nested ils
+  case res of
+    Left err -> do
+      annotateShow err
+      failure
+    Right a -> pure a
+
+doParse :: (Show ann, Monad m) => Parser' ann a -> Nested ann -> PropertyT m a
+doParse pa input = do
+  let res = runParser pa input
+  case res of
+    Left err -> do
+      annotateShow err
+      failure
+    Right a -> pure a
+
+test_fulltrip_1 :: Property
+test_fulltrip_1 =
+  withTests 1 . property $ do
+    let str = "def a():\n   return 2 + 3"
+    tks <- doTokenize str
+    length tks === 17
+
+    let ll = logicalLines tks
+    length ll === 2
+
+    indents <- doIndentation ll
+    length indents === 4
+
+    nested <- doNested indents
+    annotateShow nested
+
+    a <- doParse statement' nested
+    renderLines (renderStatement a) === str
+
+parseTab :: Parser' ann Whitespace
+parseTab = do
+  curTk <- currentToken
+  case curTk of
+    TkTab{} -> pure Tab
+    _ -> parseError $ ExpectedToken (TkTab ()) curTk
+
+parseSpace :: Parser' ann Whitespace
+parseSpace = do
+  curTk <- currentToken
+  case curTk of
+    TkSpace{} -> pure Space
+    _ -> parseError $ ExpectedToken (TkSpace ()) curTk
+
+test_parse_1 :: Property
+test_parse_1 =
+  withTests 1 . property $ do
+    let
+      line =
+        [ IndentedLine
+            LogicalLine
+            { llAnn = ()
+            , llSpacesTokens = []
+            , llSpaces = []
+            , llLine = [ TkTab () ]
+            , llEnd = Nothing
+            }
+        ]
+
+    nested <- doNested line
+
+    res <- doParse (parseSpace <!> parseTab) nested
+    case res of
+      Tab -> success
+      _ -> annotateShow res *> failure
+
+test_parse_2 :: Property
+test_parse_2 =
+  withTests 1 . property $ do
+    let
+      line =
+        [ IndentedLine
+            LogicalLine
+            { llAnn = ()
+            , llSpacesTokens = []
+            , llSpaces = []
+            , llLine = [ TkSpace (), TkSpace (), TkSpace (), TkSpace () ]
+            , llEnd = Nothing
+            }
+        ]
+
+    nested <- doNested line
+
+    () <$ doParse (Alt.many space) nested

--- a/test/LexerParser.hs
+++ b/test/LexerParser.hs
@@ -112,7 +112,7 @@ test_fulltrip_6 =
 test_fulltrip_7 :: Property
 test_fulltrip_7 =
   withTests 1 . property $ do
-    let str = "if False:\n pass\nelse \\\n      \\\r\n pass\n"
+    let str = "if False:\n pass\nelse \\\n      \\\r\n:\n pass\n"
 
     tks <- doTokenize str
     annotateShow tks

--- a/test/LexerParser.hs
+++ b/test/LexerParser.hs
@@ -1,4 +1,4 @@
-{-# language OverloadedStrings #-}
+{-# language OverloadedStrings, OverloadedLists #-}
 module LexerParser (lexerParserTests) where
 
 import Data.Functor.Alt ((<!>))
@@ -198,7 +198,6 @@ test_parse_1 =
         [ IndentedLine
             LogicalLine
             { llAnn = ()
-            , llSpacesTokens = []
             , llSpaces = []
             , llLine = [ TkTab () ]
             , llEnd = Nothing
@@ -220,7 +219,6 @@ test_parse_2 =
         [ IndentedLine
             LogicalLine
             { llAnn = ()
-            , llSpacesTokens = []
             , llSpaces = []
             , llLine = [ TkSpace (), TkSpace (), TkSpace (), TkSpace () ]
             , llEnd = Nothing

--- a/test/LexerParser.hs
+++ b/test/LexerParser.hs
@@ -22,7 +22,9 @@ lexerParserTests =
   , ("Test full trip 3", test_fulltrip_3)
   , ("Test full trip 4", test_fulltrip_4)
   , ("Test full trip 5", test_fulltrip_5)
-  , ("Test full trip 6", test_fulltrip_7)
+  , ("Test full trip 6", test_fulltrip_6)
+  , ("Test full trip 7", test_fulltrip_7)
+  , ("Test full trip 8", test_fulltrip_8)
   ]
 
 test_fulltrip_1 :: Property
@@ -113,6 +115,26 @@ test_fulltrip_7 :: Property
 test_fulltrip_7 =
   withTests 1 . property $ do
     let str = "if False:\n pass\nelse \\\n      \\\r\n:\n pass\n"
+
+    tks <- doTokenize str
+    annotateShow tks
+
+    let lls = logicalLines tks
+    annotateShow lls
+
+    ils <- doIndentation lls
+    annotateShow ils
+
+    nst <- doNested ils
+    annotateShow nst
+
+    a <- doToPython module_ str
+    renderModule a === str
+
+test_fulltrip_8 :: Property
+test_fulltrip_8 =
+  withTests 1 . property $ do
+    let str = "def a():\n \n pass\n pass\n"
 
     tks <- doTokenize str
     annotateShow tks

--- a/test/LexerParser.hs
+++ b/test/LexerParser.hs
@@ -22,6 +22,7 @@ lexerParserTests =
   , ("Test full trip 3", test_fulltrip_3)
   , ("Test full trip 4", test_fulltrip_4)
   , ("Test full trip 5", test_fulltrip_5)
+  , ("Test full trip 6", test_fulltrip_7)
   ]
 
 test_fulltrip_1 :: Property
@@ -86,6 +87,47 @@ test_fulltrip_5 =
 
     a <- doToPython statement str
     renderLines (renderStatement a) === str
+
+test_fulltrip_6 :: Property
+test_fulltrip_6 =
+  withTests 1 . property $ do
+    let str = "# blah\ndef boo():\n    pass\n       #bing\n    #   bop\n"
+
+    tks <- doTokenize str
+    annotateShow tks
+
+    let lls = logicalLines tks
+    length lls === 5
+    annotateShow lls
+
+    ils <- doIndentation lls
+    annotateShow ils
+
+    nst <- doNested ils
+    annotateShow nst
+
+    a <- doToPython module_ str
+    renderModule a === str
+
+test_fulltrip_7 :: Property
+test_fulltrip_7 =
+  withTests 1 . property $ do
+    let str = "if False:\n pass\nelse \\\n      \\\r\n pass\n"
+
+    tks <- doTokenize str
+    annotateShow tks
+
+    let lls = logicalLines tks
+    annotateShow lls
+
+    ils <- doIndentation lls
+    annotateShow ils
+
+    nst <- doNested ils
+    annotateShow nst
+
+    a <- doToPython module_ str
+    renderModule a === str
 
 parseTab :: Parser ann Whitespace
 parseTab = do

--- a/test/LexerParser.hs
+++ b/test/LexerParser.hs
@@ -18,6 +18,7 @@ lexerParserTests =
   [ ("Test parse 1", test_parse_1)
   , ("Test parse 2", test_parse_2)
   , ("Test full trip 1", test_fulltrip_1)
+  , ("Test full trip 2", test_fulltrip_2)
   ]
 
 test_fulltrip_1 :: Property
@@ -26,6 +27,13 @@ test_fulltrip_1 =
     let str = "def a(x, y=2, *z, **w):\n   return 2 + 3"
     a <- doToPython statement str
     renderLines (renderStatement a) === str
+
+test_fulltrip_2 :: Property
+test_fulltrip_2 =
+  withTests 1 . property $ do
+    let str = "(   1\n       *\n  3\n    )"
+    a <- doToPython (expr space) str
+    renderExpr a === str
 
 parseTab :: Parser ann Whitespace
 parseTab = do

--- a/test/LexerParser.hs
+++ b/test/LexerParser.hs
@@ -206,7 +206,6 @@ test_fulltrip_10 =
     ils <- doIndentation lls
     annotateShow $! ils
 
-
     nst <- doNested ils
     annotateShow $! nst
 
@@ -237,7 +236,6 @@ test_fulltrip_11 =
 
     ils <- doIndentation lls
     annotateShow $! ils
-
 
     nst <- doNested ils
     annotateShow $! nst

--- a/test/LexerParser.hs
+++ b/test/LexerParser.hs
@@ -25,6 +25,7 @@ lexerParserTests =
   , ("Test full trip 6", test_fulltrip_6)
   , ("Test full trip 7", test_fulltrip_7)
   , ("Test full trip 8", test_fulltrip_8)
+  , ("Test full trip 9", test_fulltrip_9)
   ]
 
 test_fulltrip_1 :: Property
@@ -149,6 +150,30 @@ test_fulltrip_8 =
     annotateShow nst
 
     a <- doToPython module_ str
+    renderModule a === str
+
+test_fulltrip_9 :: Property
+test_fulltrip_9 =
+  withTests 1 . property $ do
+    let
+      str =
+        "try:\n pass\nexcept False:\n pass\nelse:\n pass\nfinally:\n pass\n def a():\n  pass\n pass\n"
+
+    tks <- doTokenize str
+    annotateShow tks
+
+    let lls = logicalLines tks
+    annotateShow lls
+
+    ils <- doIndentation lls
+    annotateShow ils
+
+    nst <- doNested ils
+    annotateShow nst
+
+    a <- doParse module_ nst
+    annotateShow a
+
     renderModule a === str
 
 parseTab :: Parser ann Whitespace

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -39,7 +39,7 @@ validateExprSyntax' = runValidateSyntax initialSyntaxContext [] . validateExprSy
 validateExprIndentation'
   :: Expr '[] a
   -> Validate [IndentationError '[] a] (Expr '[Indentation] a)
-validateExprIndentation' = validateExprIndentation
+validateExprIndentation' = runValidateIndentation . validateExprIndentation
 
 validateStatementSyntax'
   :: Statement '[Indentation] a
@@ -50,7 +50,7 @@ validateStatementSyntax' =
 validateStatementIndentation'
   :: Statement '[] a
   -> Validate [IndentationError '[] a] (Statement '[Indentation] a)
-validateStatementIndentation' = validateStatementIndentation
+validateStatementIndentation' = runValidateIndentation . validateStatementIndentation
 
 validateModuleSyntax'
   :: Module '[Indentation] a
@@ -61,7 +61,7 @@ validateModuleSyntax' =
 validateModuleIndentation'
   :: Module '[] a
   -> Validate [IndentationError '[] a] (Module '[Indentation] a)
-validateModuleIndentation' = validateModuleIndentation
+validateModuleIndentation' = runValidateIndentation . validateModuleIndentation
 
 runPython3 :: (MonadTest m, MonadIO m) => FilePath -> Bool -> String -> m ()
 runPython3 path shouldSucceed str = do

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -179,7 +179,7 @@ expr_printparseprint_print =
         case validateExprSyntax' res of
           Failure errs' -> annotateShow errs' *> failure
           Success res' -> do
-            py <- doToPython expr (renderExpr res')
+            py <- doToPython (expr space) (renderExpr res')
             renderExpr (res' ^. unvalidated) === renderExpr (res $> ())
 
 statement_printparseprint_print :: Property

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -10,6 +10,7 @@ import Language.Python.Validate.Indentation.Error
 import Language.Python.Validate.Syntax
 import Language.Python.Validate.Syntax.Error
 
+import LexerParser
 import Scope
 import Roundtrip
 
@@ -220,6 +221,7 @@ statement_printparse_id =
               Trifecta.Success res'' -> res ^. unvalidated === st
 
 main = do
+  checkParallel lexerParserTests
   let file = "hedgehog-test.py"
   check . withTests 200 $ syntax_expr file
   check . withTests 200 $ syntax_statement file

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -197,20 +197,6 @@ statement_printparseprint_print =
             renderLines (renderStatement (res' ^. unvalidated)) ===
               renderLines (renderStatement (py $> ()))
 
-statement_printparse_id :: Property
-statement_printparse_id =
-  property $ do
-    st <- forAll $ evalStateT Correct.genStatement Correct.initialGenState
-    annotate (renderLines $ renderStatement st)
-    case validateStatementIndentation' st of
-      Failure errs -> annotateShow errs *> failure
-      Success res ->
-        case validateStatementSyntax' res of
-          Failure errs' -> annotateShow errs' *> failure
-          Success res' -> do
-            py <- doToPython statement . renderLines $ renderStatement res'
-            res' ^. unvalidated === (() <$ py)
-
 main = do
   checkParallel lexerParserTests
   let file = "hedgehog-test.py"
@@ -221,7 +207,6 @@ main = do
   check . withTests 200 $ correct_syntax_statement file
   check expr_printparseprint_print
   check . withShrinks 2000 $ statement_printparseprint_print
-  check . withShrinks 2000 $ statement_printparse_id
   checkParallel scopeTests
   checkParallel roundtripTests
   removeFile "hedgehog-test.py"

--- a/test/Roundtrip.hs
+++ b/test/Roundtrip.hs
@@ -12,7 +12,8 @@ import Text.Trifecta (Caret)
 
 import Language.Python.Internal.Parse (module_)
 import Language.Python.Internal.Render (renderModule)
-import Language.Python.Validate.Indentation (Indentation, validateModuleIndentation)
+import Language.Python.Validate.Indentation
+  (Indentation, runValidateIndentation, validateModuleIndentation)
 import Language.Python.Validate.Indentation.Error (IndentationError)
 import Language.Python.Validate.Syntax
   (validateModuleSyntax, runValidateSyntax, initialSyntaxContext)
@@ -36,7 +37,7 @@ doRoundtrip name =
   property $ do
     file <- liftIO . readFile $ "test/files" </> name
     py <- doToPython module_ file
-    case validateModuleIndentation py of
+    case runValidateIndentation $ validateModuleIndentation py of
       Failure errs -> annotateShow (errs :: [IndentationError '[] Caret]) *> failure
       Success res ->
         case runValidateSyntax initialSyntaxContext [] (validateModuleSyntax res) of

--- a/test/Roundtrip.hs
+++ b/test/Roundtrip.hs
@@ -24,9 +24,9 @@ roundtripTests :: Group
 roundtripTests =
   Group "Roundtrip tests" $
   (\name -> (fromString name, withTests 1 $ doRoundtrip name)) <$>
-  [ "django.py"
+  [ "weird.py"
+  , "django.py"
   , "test.py"
-  , "weird.py"
   , "ansible.py"
   , "comments.py"
   ]

--- a/test/Scope.hs
+++ b/test/Scope.hs
@@ -38,7 +38,7 @@ validate
           [ScopeError '[Syntax, Indentation] ()]
           (Statement '[Scope, Syntax, Indentation] ()))
 validate x =
-  case validateStatementIndentation x of
+  case runValidateIndentation $ validateStatementIndentation x of
     Failure errs -> do
       annotateShow (errs :: [IndentationError '[] ()])
       failure


### PR DESCRIPTION
I kept encountering parsing bugs that involved newlines and indentation, so I've broken parsing down into multiple stages to make it all easier to reason about.

Stage 0: Tokenize - break the string into a sequence of tokens. This could generate lexical errors if there are unrecognized characters

Stage 1: Lines - break the tokens into Python's "logical lines", which may begin with some indentation. This is just a refinement of the tokens sequence, so no errors can occur

Stage 2: Indentation - interleave Indent and Dedent throughout the logical lines to mark where blocks begin and end. This can generate indentation errors if the user mixes tabs and spaces inconsistently or dedents to some unknown indentation level.

Stage 3: Nesting - use the Indent and Dedent markers to create a nested data structure. The errors here are mainly sanity checks. A well-formed input shouldn't trigger any errors.

Stage 4: Parsing - decode the nested datatype using the Python grammar. This can generate many different grammar-related errors. Error reporting here needs to be improved, but I don't think that will be as difficult as getting the same functionality using the old parser

----

Indentation has been made local to each statement. Before, each level of indentation was stored outside statements by the Block datatype. That method was inaccurate because blank lines are not considered to have any level of indentation, but nested block statements imposed indentation levels anyway.

Now, each statement is preceded by data which is isomorphic to `[[Whitespace]]`, which represents its indentation. This indentation has been broken up into levels, so that we have still retained the ability to transform indentation styles across the whole program. The disadvantage is that users now have to be conscious of indentation to write successful program transformations. At this stage I think it's a necessary disadvantage, because the previous implementation, while convenient, was plain incorrect.