### PR TITLE
Fixed "token munging"

### DIFF
--- a/hpython.cabal
+++ b/hpython.cabal
@@ -23,6 +23,7 @@ library
                      , Language.Python.Internal.Parse
                      , Language.Python.Internal.Render
                      , Language.Python.Internal.Syntax
+                     , Language.Python.Internal.Token
                      , Language.Python.Internal.Syntax.BinOp
                      , Language.Python.Internal.Syntax.Comment
                      , Language.Python.Internal.Syntax.CommaSep

--- a/src/Language/Python/Internal/Lexer.hs
+++ b/src/Language/Python/Internal/Lexer.hs
@@ -1,9 +1,6 @@
-{-# language DeriveFunctor #-}
 {-# language BangPatterns #-}
 {-# language OverloadedLists #-}
 {-# language TypeApplications #-}
-{-# language TemplateHaskell #-}
-{-# language ViewPatterns #-}
 module Language.Python.Internal.Lexer where
 
 import Control.Applicative ((<|>), some, many, optional)
@@ -14,7 +11,6 @@ import Control.Monad.Except (throwError)
 import Control.Monad.State (StateT, evalStateT, get, modify, put)
 import Data.Bifunctor (first)
 import Data.Char (chr, isAscii)
-import Data.Deriving (deriveEq1)
 import Data.Foldable (asum)
 import Data.Functor (($>))
 import Data.List.NonEmpty (NonEmpty(..))
@@ -38,139 +34,7 @@ import Language.Python.Internal.Syntax.Whitespace
   , getIndentLevel, indentLevel
   , absoluteIndentLevel
   )
-
-data QuoteType = SingleQuote | DoubleQuote
-  deriving (Eq, Show)
-
-data PyToken a
-  = TkIf a
-  | TkElse a
-  | TkWhile a
-  | TkDef a
-  | TkReturn a
-  | TkPass a
-  | TkBreak a
-  | TkContinue a
-  | TkTrue a
-  | TkFalse a
-  | TkOr a
-  | TkAnd a
-  | TkIs a
-  | TkNot a
-  | TkGlobal a
-  | TkDel a
-  | TkImport a
-  | TkFrom a
-  | TkAs a
-  | TkRaise a
-  | TkTry a
-  | TkExcept a
-  | TkFinally a
-  | TkClass a
-  | TkFor a
-  | TkIn a
-  | TkInt Integer a
-  | TkFloat Integer (Maybe Integer) a
-  | TkIdent String a
-  | TkShortString (Maybe StringPrefix) QuoteType String a
-  | TkLongString (Maybe StringPrefix) QuoteType String a
-  | TkSpace a
-  | TkTab a
-  | TkNewline Newline a
-  | TkLeftBracket a
-  | TkRightBracket a
-  | TkLeftParen a
-  | TkRightParen a
-  | TkLeftBrace a
-  | TkRightBrace a
-  | TkLt a
-  | TkLte a
-  | TkEq a
-  | TkDoubleEq a
-  | TkGt a
-  | TkGte a
-  | TkContinued Newline a
-  | TkColon a
-  | TkSemicolon a
-  | TkComma a
-  | TkDot a
-  | TkPlus a
-  | TkMinus a
-  | TkComment String a
-  | TkStar a
-  | TkDoubleStar a
-  | TkSlash a
-  | TkDoubleSlash a
-  | TkPercent a
-  | TkShiftLeft a
-  | TkShiftRight a
-  deriving (Eq, Show, Functor)
-deriveEq1 ''PyToken
-
-pyTokenAnn :: PyToken a -> a
-pyTokenAnn tk =
-  case tk of
-    TkDef a -> a
-    TkReturn a -> a
-    TkPass a -> a
-    TkBreak a -> a
-    TkContinue a -> a
-    TkTrue a -> a
-    TkFalse a -> a
-    TkOr a -> a
-    TkAnd a -> a
-    TkIs a -> a
-    TkNot a -> a
-    TkGlobal a -> a
-    TkDel a -> a
-    TkImport a -> a
-    TkFrom a -> a
-    TkAs a -> a
-    TkRaise a -> a
-    TkTry a -> a
-    TkExcept a -> a
-    TkFinally a -> a
-    TkClass a -> a
-    TkFor a -> a
-    TkIn a -> a
-    TkPlus a -> a
-    TkMinus a -> a
-    TkIf a -> a
-    TkElse a -> a
-    TkWhile a -> a
-    TkInt _ a -> a
-    TkFloat _ _ a -> a
-    TkIdent _ a -> a
-    TkShortString _ _ _ a -> a
-    TkLongString _ _ _ a -> a
-    TkSpace a -> a
-    TkTab a -> a
-    TkNewline _ a -> a
-    TkLeftBracket a -> a
-    TkRightBracket a -> a
-    TkLeftParen a -> a
-    TkRightParen a -> a
-    TkLeftBrace a -> a
-    TkRightBrace a -> a
-    TkLt a -> a
-    TkLte a -> a
-    TkEq a -> a
-    TkDoubleEq a -> a
-    TkGt a -> a
-    TkGte a -> a
-    TkContinued _ a -> a
-    TkColon a -> a
-    TkSemicolon a -> a
-    TkComma a -> a
-    TkDot a -> a
-    TkComment _ a -> a
-    TkStar a -> a
-    TkDoubleStar a -> a
-    TkSlash a -> a
-    TkDoubleSlash a -> a
-    TkPercent a -> a
-    TkShiftLeft a -> a
-    TkShiftRight a -> a
+import Language.Python.Internal.Token (PyToken(..), QuoteType(..), pyTokenAnn)
 
 parseNewline :: CharParsing m => m Newline
 parseNewline =

--- a/src/Language/Python/Internal/Lexer.hs
+++ b/src/Language/Python/Internal/Lexer.hs
@@ -15,7 +15,7 @@ import Data.Foldable (asum)
 import Data.Functor (($>))
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Semigroup ((<>))
-import Data.Sequence ((|>), ViewR(..), ViewL(..), Seq)
+import Data.Sequence ((!?), (|>), ViewR(..), ViewL(..), Seq)
 import Text.Parser.LookAhead (LookAheadParsing, lookAhead)
 import Text.Trifecta
   ( CharParsing, DeltaParsing, Caret, Careted(..), char, careted, letter, noneOf
@@ -353,6 +353,9 @@ newtype Nested a
   = Nested
   { unNested :: Seq (Either (Nested a) (Line a))
   } deriving (Eq, Show)
+
+nestedAnnotation :: Nested a -> Maybe a
+nestedAnnotation (Nested s) = s !? 0 >>= either nestedAnnotation (pure . lineAnn)
 
 data IndentationError
   = UnexpectedDedent

--- a/src/Language/Python/Internal/Parse.hs
+++ b/src/Language/Python/Internal/Parse.hs
@@ -23,6 +23,7 @@ import qualified Data.List.NonEmpty as NonEmpty
 
 import Language.Python.Internal.Lexer
 import Language.Python.Internal.Syntax
+import Language.Python.Internal.Token
 
 some1 :: (Alt f, Applicative f) => f a -> f (NonEmpty a)
 some1 a = (:|) <$> a <*> many a

--- a/src/Language/Python/Internal/Parse.hs
+++ b/src/Language/Python/Internal/Parse.hs
@@ -372,7 +372,7 @@ smallStatement =
     returnSt =
       (\(tkReturn, retSpaces) -> Return (pyTokenAnn tkReturn) retSpaces) <$>
       token space (TkReturn ()) <*>
-      expr space
+      exprList space
 
     passSt = Pass . pyTokenAnn <$> tokenEq (TkPass ())
     breakSt = Break . pyTokenAnn <$> tokenEq (TkBreak ())

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -18,7 +18,7 @@ import Control.Lens.Getter (view)
 import Control.Lens.Setter (over)
 import Control.Lens.Traversal (Traversal')
 import Control.Lens.Wrapped (_Wrapped)
-import Control.Lens.Plated (transform)
+import Control.Lens.Plated (rewrite)
 import Data.Char (ord)
 import Data.Foldable (toList)
 import Data.Maybe (fromMaybe, maybe)
@@ -46,10 +46,13 @@ showRenderOutput =
   unRenderOutput
   where
     correctNewlines =
-      transform $
+      rewrite $
       \case
-        TkNewline CR () : TkNewline LF () : rest -> TkNewline CRLF () : TkNewline LF () : rest
-        input -> input
+        TkNewline CR () : TkNewline LF () : rest ->
+          Just $ TkNewline CRLF () : TkNewline LF () : rest
+        TkContinued CR () : TkNewline LF () : rest ->
+          Just $ TkContinued CRLF () : TkNewline LF () : rest
+        _ -> Nothing
 
 showStringPrefix :: StringPrefix -> String
 showStringPrefix sp =
@@ -95,7 +98,7 @@ showToken t =
     TkNot{} -> "not"
     TkGlobal{} -> "global"
     TkNonlocal{} -> "nonlocal"
-    TkDel{} -> "defl"
+    TkDel{} -> "del"
     TkImport{} -> "import"
     TkFrom{} -> "from"
     TkAs{} -> "as"
@@ -159,8 +162,8 @@ showToken t =
     TkComment s _ -> "#" <> s
     TkStar{} -> "*"
     TkDoubleStar{} -> "**"
-    TkSlash{} -> "\\"
-    TkDoubleSlash{} -> "\\\\"
+    TkSlash{} -> "/"
+    TkDoubleSlash{} -> "//"
     TkPercent{} -> "%"
     TkShiftLeft{} -> "<<"
     TkShiftRight{} -> ">>"

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -1,20 +1,174 @@
 {-# language GeneralizedNewtypeDeriving, DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
-module Language.Python.Internal.Render where
+{-# language FlexibleInstances, MultiParamTypeClasses #-}
+{-# language LambdaCase #-}
+module Language.Python.Internal.Render
+  ( RenderOutput, showRenderOutput, singleton, cons
+  , showQuoteType, showStringPrefix, showToken
+  , showModule, showStatement, showExpr
+  , renderModule, renderStatement, renderExpr
+  , bracket, renderWhitespace, renderCommaSep, renderCommaSep1, renderCommaSep1'
+  , renderIdent, renderComment, renderModuleName, renderDot, renderRelativeModuleName
+  , renderImportAs, renderImportTargets, renderSmallStatement, renderCompoundStatement
+  , renderBlock, renderIndent, renderIndents, renderExceptAs, renderArg, renderParam
+  , renderBinOp
+  )
+where
 
-import Control.Lens.Getter
+import Control.Lens.Getter (view)
 import Control.Lens.Setter (over)
 import Control.Lens.Traversal (Traversal')
-import Control.Lens.Wrapped
+import Control.Lens.Wrapped (_Wrapped)
+import Control.Lens.Plated (transform)
 import Data.Char (ord)
-import Data.Maybe
+import Data.Foldable (toList)
+import Data.Maybe (fromMaybe, maybe)
 import Data.Semigroup (Semigroup(..))
 
 import Language.Python.Internal.Syntax
+import Language.Python.Internal.Token (PyToken(..), QuoteType(..))
 
-bracket :: String -> String
-bracket a = "(" <> a <> ")"
+newtype RenderOutput
+  = RenderOutput
+  { unRenderOutput :: [PyToken ()]
+  } deriving (Eq, Show, Semigroup, Monoid)
 
-bracketTuple :: Expr v a -> String
+singleton :: PyToken () -> RenderOutput
+singleton a = RenderOutput [a]
+
+cons :: PyToken () -> RenderOutput -> RenderOutput
+cons a (RenderOutput b) = RenderOutput $ a : b
+infixr 5 `cons`
+
+showRenderOutput :: RenderOutput -> String
+showRenderOutput =
+  foldMap showToken .
+  correctNewlines .
+  unRenderOutput
+  where
+    correctNewlines =
+      transform $
+      \case
+        TkNewline CR () : TkNewline LF () : rest -> TkNewline CRLF () : TkNewline LF () : rest
+        input -> input
+
+showStringPrefix :: StringPrefix -> String
+showStringPrefix sp =
+  case sp of
+    Prefix_r -> "r"
+    Prefix_R -> "R"
+    Prefix_u -> "u"
+    Prefix_U -> "U"
+    Prefix_b -> "b"
+    Prefix_B -> "B"
+    Prefix_br -> "br"
+    Prefix_Br -> "Br"
+    Prefix_bR -> "bR"
+    Prefix_BR -> "BR"
+    Prefix_rb -> "rb"
+    Prefix_rB -> "rB"
+    Prefix_Rb -> "Rb"
+    Prefix_RB -> "RB"
+
+showQuoteType :: QuoteType -> String
+showQuoteType qt =
+  case qt of
+    DoubleQuote -> "\""
+    SingleQuote -> "\'"
+
+showToken :: PyToken a -> String
+showToken t =
+  case t of
+    TkIf{} -> "if"
+    TkElse{} -> "else"
+    TkWhile{} -> "while"
+    TkDef{} -> "def"
+    TkReturn{} -> "return"
+    TkPass{} -> "pass"
+    TkBreak{} -> "break"
+    TkContinue{} -> "continue"
+    TkTrue{} -> "True"
+    TkFalse{} -> "False"
+    TkNone{} -> "None"
+    TkOr{} -> "or"
+    TkAnd{} -> "and"
+    TkIs{} -> "is"
+    TkNot{} -> "not"
+    TkGlobal{} -> "global"
+    TkNonlocal{} -> "nonlocal"
+    TkDel{} -> "defl"
+    TkImport{} -> "import"
+    TkFrom{} -> "from"
+    TkAs{} -> "as"
+    TkRaise{} -> "raise"
+    TkTry{} -> "try"
+    TkExcept{} -> "except"
+    TkFinally{} -> "finally"
+    TkClass{} -> "class"
+    TkFor{} -> "for"
+    TkIn{} -> "in"
+    TkInt i _ -> show i
+    TkFloat i i' _ -> show i <> foldMap (("." <>) . show) i'
+    TkIdent s _ -> s
+    TkShortString sp qt s _ ->
+      let
+        quote = showQuoteType qt
+      in
+        foldMap showStringPrefix sp <>
+        quote <>
+        foldMap renderChar s <>
+        quote
+    TkLongString sp qt s _ ->
+      let
+        quote = showQuoteType qt >>= replicate 3
+      in
+        foldMap showStringPrefix sp <>
+        quote <>
+        foldMap renderChar s <>
+        quote
+    TkSpace{} -> " "
+    TkTab{} -> "\t"
+    TkNewline nl _ ->
+      case nl of
+        CR -> "\r"
+        LF -> "\n"
+        CRLF -> "\r\n"
+    TkLeftBracket{} -> "["
+    TkRightBracket{} -> "]"
+    TkLeftParen{} -> "("
+    TkRightParen{} -> ")"
+    TkLeftBrace{} -> "{"
+    TkRightBrace{} -> "}"
+    TkLt{} -> "<"
+    TkLte{} -> "<="
+    TkEq{} -> "="
+    TkDoubleEq{}-> "=="
+    TkGt{} -> ">"
+    TkGte{} -> ">="
+    TkContinued nl _ ->
+      "\\" <>
+      case nl of
+        CR -> "\r"
+        LF -> "\n"
+        CRLF -> "\r\n"
+    TkColon{} -> ":"
+    TkSemicolon{} -> ";"
+    TkComma{} -> ","
+    TkDot{} -> "."
+    TkPlus{} -> "+"
+    TkMinus{} -> "-"
+    TkComment s _ -> "#" <> s
+    TkStar{} -> "*"
+    TkDoubleStar{} -> "**"
+    TkSlash{} -> "\\"
+    TkDoubleSlash{} -> "\\\\"
+    TkPercent{} -> "%"
+    TkShiftLeft{} -> "<<"
+    TkShiftRight{} -> ">>"
+
+bracket :: RenderOutput -> RenderOutput
+bracket a = TkLeftParen () `cons` a <> singleton (TkRightParen ())
+
+bracketTuple :: Expr v a -> RenderOutput
 bracketTuple e =
   case e of
     Tuple{} -> bracket $ renderExpr e
@@ -93,10 +247,10 @@ endWith nl (ManyLines a nl' as) =
     (case as of; NoLines -> nl; _ -> nl')
     (case as of; NoLines -> NoLines; _ -> endWith nl as)
 
-renderLines :: Lines String -> String
-renderLines NoLines = ""
-renderLines (OneLine a) = a
-renderLines (ManyLines a nl ls) = a <> renderNewline nl <> renderLines ls
+renderLines :: (a -> RenderOutput) -> Lines a -> RenderOutput
+renderLines _ NoLines = mempty
+renderLines f (OneLine a) = f a
+renderLines f (ManyLines a nl ls) = f a <> singleton (renderNewline nl) <> renderLines f ls
 
 instance Semigroup a => Semigroup (Lines a) where
   NoLines <> a = a
@@ -109,255 +263,242 @@ instance Semigroup a => Monoid (Lines a) where
   mempty = NoLines
   mappend = (<>)
 
-renderAnyWhitespace :: Either Newline Whitespace -> String
-renderAnyWhitespace (Left nl) = renderNewline nl
-renderAnyWhitespace (Right sp) = renderWhitespace sp
+renderWhitespace :: Whitespace -> RenderOutput
+renderWhitespace Space = singleton $ TkSpace ()
+renderWhitespace Tab = singleton $ TkTab ()
+renderWhitespace (Continued nl ws) = TkContinued nl () `cons` foldMap renderWhitespace ws
+renderWhitespace (Newline nl) = singleton $ TkNewline nl ()
 
-renderWhitespace :: Whitespace -> String
-renderWhitespace Space = " "
-renderWhitespace Tab = "\t"
-renderWhitespace (Continued nl ws) = "\\" <> renderNewline nl <> foldMap renderWhitespace ws
-renderWhitespace (Newline nl) = renderNewline nl
+renderNewline :: Newline -> PyToken ()
+renderNewline nl = TkNewline nl ()
 
-renderNewline :: Newline -> String
-renderNewline CR = "\r"
-renderNewline LF = "\n"
-renderNewline CRLF = "\r\n"
-
-renderCommaSep :: (a -> String) -> CommaSep a -> String
+renderCommaSep :: (a -> RenderOutput) -> CommaSep a -> RenderOutput
 renderCommaSep _ CommaSepNone = mempty
 renderCommaSep f (CommaSepOne a) = f a
 renderCommaSep f (CommaSepMany a ws2 c) =
-  f a <> "," <>
+  f a <>
+  singleton (TkComma ()) <>
   foldMap renderWhitespace ws2 <>
   renderCommaSep f c
 
-renderCommaSep1 :: (a -> String) -> CommaSep1 a -> String
+renderCommaSep1 :: (a -> RenderOutput) -> CommaSep1 a -> RenderOutput
 renderCommaSep1 f (CommaSepOne1 a) = f a
 renderCommaSep1 f (CommaSepMany1 a ws2 c) =
-  f a <> "," <>
+  f a <>
+  singleton (TkComma ()) <>
   foldMap renderWhitespace ws2 <>
   renderCommaSep1 f c
 
-renderCommaSep1' :: (a -> String) -> CommaSep1' a -> String
+renderCommaSep1' :: (a -> RenderOutput) -> CommaSep1' a -> RenderOutput
 renderCommaSep1' f (CommaSepOne1' a b) =
   f a <>
-  foldMap (\x -> "," <> foldMap renderWhitespace x) b
+  foldMap (\x -> TkComma () `cons` foldMap renderWhitespace x) b
 renderCommaSep1' f (CommaSepMany1' a ws2 c) =
-  f a <> "," <> foldMap renderWhitespace ws2 <>
+  f a <>
+  singleton (TkComma ()) <>
+  foldMap renderWhitespace ws2 <>
   renderCommaSep1' f c
 
-renderIdent :: Ident v a -> String
-renderIdent (MkIdent _ a b) = a <> foldMap renderWhitespace b
+renderIdent :: Ident v a -> RenderOutput
+renderIdent (MkIdent _ a b) = TkIdent a () `cons` foldMap renderWhitespace b
 
-renderComment :: Comment -> String
-renderComment (Comment s) = "#" <> s
+renderComment :: Comment -> PyToken ()
+renderComment (Comment s) = TkComment s ()
 
-renderPrefix :: StringPrefix -> String
-renderPrefix p =
-  case p of
-    Prefix_r -> "r"
-    Prefix_R -> "R"
-    Prefix_u -> "u"
-    Prefix_U -> "U"
-    Prefix_b -> "b"
-    Prefix_B -> "B"
-    Prefix_br -> "br"
-    Prefix_Br -> "Br"
-    Prefix_bR -> "bR"
-    Prefix_BR -> "BR"
-    Prefix_rb -> "rb"
-    Prefix_rB -> "rB"
-    Prefix_Rb -> "Rb"
-    Prefix_RB -> "RB"
-
-renderExpr :: Expr v a -> String
+renderExpr :: Expr v a -> RenderOutput
 renderExpr (Not _ ws e) =
-  "not" <>
+  TkNot () `cons`
   foldMap renderWhitespace ws <>
   case e of
-    BinOp _ _ BoolAnd{} _ -> "(" <> renderExpr e <> ")"
-    BinOp _ _ BoolOr{} _ -> "(" <> renderExpr e <> ")"
+    BinOp _ _ BoolAnd{} _ -> bracket $ renderExpr e
+    BinOp _ _ BoolOr{} _ -> bracket $ renderExpr e
     _ -> bracketTuple e
 renderExpr (Parens _ ws1 e ws2) =
-  "(" <> foldMap renderWhitespace ws1 <>
-  renderExpr e <> ")" <> foldMap renderWhitespace ws2
-renderExpr (Bool _ b ws) = show b <> foldMap renderWhitespace ws
+  bracket (foldMap renderWhitespace ws1 <> renderExpr e) <>
+  foldMap renderWhitespace ws2
+renderExpr (Bool _ b ws) =
+  (if b then TkTrue () else TkFalse ()) `cons`
+  foldMap renderWhitespace ws
 renderExpr (Negate _ ws expr) =
-  "-" <> foldMap renderWhitespace ws <>
-    case expr of
-      BinOp _ _ Exp{} _ -> renderExpr expr
-      BinOp{} -> "(" <> renderExpr expr <> ")"
-      _ -> renderExpr expr
+  TkMinus () `cons`
+  foldMap renderWhitespace ws <>
+  case expr of
+    BinOp _ _ Exp{} _ -> renderExpr expr
+    BinOp{} -> bracket $ renderExpr expr
+    _ -> renderExpr expr
 renderExpr (String _ prefix strType b ws) =
-  let
-    quote =
-      case strType of
-        ShortSingle -> "'"
-        ShortDouble -> "\""
-        LongSingle -> "'''"
-        LongDouble -> "\"\"\""
-  in
-    foldMap renderPrefix prefix <> quote <>
-    foldMap renderChar b <> quote <> foldMap renderWhitespace ws
-renderExpr (Int _ n ws) = show n <> foldMap renderWhitespace ws
+  (case strType of
+      ShortSingle -> TkShortString prefix SingleQuote b ()
+      ShortDouble -> TkShortString prefix DoubleQuote b ()
+      LongSingle -> TkLongString prefix SingleQuote b ()
+      LongDouble -> TkLongString prefix DoubleQuote b ()) `cons`
+  foldMap renderWhitespace ws
+renderExpr (Int _ n ws) = TkInt n () `cons` foldMap renderWhitespace ws
 renderExpr (Ident _ name) = renderIdent name
 renderExpr (List _ ws1 exprs ws2) =
-  "[" <> foldMap renderWhitespace ws1 <>
+  TkLeftBracket () `cons`
+  foldMap renderWhitespace ws1 <>
   foldMap
     (renderCommaSep1' bracketTuple)
     exprs <>
-  "]" <> foldMap renderWhitespace ws2
+  singleton (TkRightBracket ()) <> foldMap renderWhitespace ws2
 renderExpr (Call _ expr ws args ws2) =
   (case expr of
-     Int _ n _ | n < 0 -> "(" <> renderExpr expr <> ")"
-     BinOp{} -> "(" <> renderExpr expr <> ")"
-     Tuple{} -> "(" <> renderExpr expr <> ")"
-     Not{} -> "(" <> renderExpr expr <> ")"
+     Int _ n _ | n < 0 -> bracket $ renderExpr expr
+     BinOp{} -> bracket $ renderExpr expr
+     Tuple{} -> bracket $ renderExpr expr
+     Not{} -> bracket $ renderExpr expr
      _ -> renderExpr expr) <>
-  "(" <> foldMap renderWhitespace ws <> renderCommaSep renderArg args <>
-  ")" <> foldMap renderWhitespace ws2
+  bracket (foldMap renderWhitespace ws <> renderCommaSep renderArg args) <>
+  foldMap renderWhitespace ws2
 renderExpr (Deref _ expr ws name) =
   (case expr of
-    Int{} -> "(" <> renderExpr expr <> ")"
-    BinOp{} -> "(" <> renderExpr expr <> ")"
-    Tuple{} -> "(" <> renderExpr expr <> ")"
-    Not{} -> "(" <> renderExpr expr <> ")"
+    Int{} -> bracket $ renderExpr expr
+    BinOp{} -> bracket $ renderExpr expr
+    Tuple{} -> bracket $ renderExpr expr
+    Not{} -> bracket $ renderExpr expr
     _ -> renderExpr expr) <>
-  "." <>
+  singleton (TkDot ()) <>
   foldMap renderWhitespace ws <>
   renderIdent name
-renderExpr (None _ ws) = "None" <> foldMap renderWhitespace ws
+renderExpr (None _ ws) = TkNone () `cons` foldMap renderWhitespace ws
 renderExpr (BinOp _ e1 op e2) =
   (if shouldBracketLeft op e1 then bracket else id) (renderExpr e1) <>
   renderBinOp op <>
   (if shouldBracketRight op e2 then bracket else id) (renderExpr e2)
 renderExpr (Tuple _ a ws c) =
-  bracketTuple a <> "," <> foldMap renderWhitespace ws <>
+  bracketTuple a <> singleton (TkComma ()) <> foldMap renderWhitespace ws <>
   foldMap
     (renderCommaSep1' bracketTuple)
     c
 
-renderModuleName :: ModuleName v a -> String
+renderModuleName :: ModuleName v a -> RenderOutput
 renderModuleName (ModuleNameOne _ s) = renderIdent s
 renderModuleName (ModuleNameMany _ n ws2 rest) =
-  renderIdent n <> "." <> foldMap renderWhitespace ws2 <>
+  renderIdent n <> singleton (TkDot ()) <> foldMap renderWhitespace ws2 <>
   renderModuleName rest
 
-renderDot :: Dot -> String
-renderDot (Dot ws) = "." <> foldMap renderWhitespace ws
+renderDot :: Dot -> RenderOutput
+renderDot (Dot ws) = TkDot () `cons` foldMap renderWhitespace ws
 
-renderRelativeModuleName :: RelativeModuleName v a -> String
+renderRelativeModuleName :: RelativeModuleName v a -> RenderOutput
 renderRelativeModuleName (RelativeWithName ds mn) =
   foldMap renderDot ds <> renderModuleName mn
 renderRelativeModuleName (Relative ds) =
   foldMap renderDot ds
 
-renderImportAs :: (e a -> String) -> ImportAs e v a -> String
+renderImportAs :: (e a -> RenderOutput) -> ImportAs e v a -> RenderOutput
 renderImportAs f (ImportAs _ ea m) =
-  f ea <> foldMap (\(a, b) -> "as" <> foldMap renderWhitespace a <> renderIdent b) m
+  f ea <>
+  foldMap (\(a, b) -> TkAs () `cons` foldMap renderWhitespace a <> renderIdent b) m
 
-renderImportTargets :: ImportTargets v a -> String
-renderImportTargets (ImportAll _ ws) = "*" <> foldMap renderWhitespace ws
+renderImportTargets :: ImportTargets v a -> RenderOutput
+renderImportTargets (ImportAll _ ws) = TkStar () `cons` foldMap renderWhitespace ws
 renderImportTargets (ImportSome _ ts) =
   renderCommaSep1 (renderImportAs renderIdent) ts
 renderImportTargets (ImportSomeParens _ ws1 ts ws2) =
-  "(" <> foldMap renderWhitespace ws1 <>
-  renderCommaSep1' (renderImportAs renderIdent) ts <>
-  ")" <> foldMap renderWhitespace ws2
+  bracket
+    (foldMap renderWhitespace ws1 <> renderCommaSep1' (renderImportAs renderIdent) ts) <>
+  foldMap renderWhitespace ws2
 
-renderSmallStatement :: SmallStatement v a -> String
+renderSmallStatement :: SmallStatement v a -> RenderOutput
 renderSmallStatement (Raise _ ws x) =
-  "raise" <> foldMap renderWhitespace ws <>
+  TkRaise () `cons` foldMap renderWhitespace ws <>
   foldMap
     (\(b, c) ->
        bracketTuple b <>
        foldMap
          (\(d, e) ->
-            "from" <> foldMap renderWhitespace d <>
+            TkFrom () `cons` foldMap renderWhitespace d <>
             bracketTuple e)
          c)
     x
 renderSmallStatement (Return _ ws expr) =
-  "return" <> foldMap renderWhitespace ws <> renderExpr expr
+  TkReturn () `cons` foldMap renderWhitespace ws <> renderExpr expr
 renderSmallStatement (Expr _ expr) = renderExpr expr
 renderSmallStatement (Assign _ lvalue ws2 rvalue) =
-  renderExpr lvalue <> "=" <>
+  renderExpr lvalue <> singleton (TkEq ()) <>
   foldMap renderWhitespace ws2 <> renderExpr rvalue
-renderSmallStatement (Pass _) = "pass"
-renderSmallStatement (Continue _) = "continue"
-renderSmallStatement (Break _) = "break"
+renderSmallStatement (Pass _) = singleton $ TkPass ()
+renderSmallStatement (Continue _) = singleton $ TkContinue ()
+renderSmallStatement (Break _) = singleton $ TkBreak ()
 renderSmallStatement (Global _ ws ids) =
-  "global" <> foldMap renderWhitespace ws <> renderCommaSep1 renderIdent ids
+  TkGlobal () `cons` foldMap renderWhitespace ws <> renderCommaSep1 renderIdent ids
 renderSmallStatement (Nonlocal _ ws ids) =
-  "nonlocal" <> foldMap renderWhitespace ws <> renderCommaSep1 renderIdent ids
+  TkNonlocal () `cons` foldMap renderWhitespace ws <> renderCommaSep1 renderIdent ids
 renderSmallStatement (Del _ ws ids) =
-  "del" <> foldMap renderWhitespace ws <> renderCommaSep1 renderIdent ids
+  TkDel () `cons` foldMap renderWhitespace ws <> renderCommaSep1 renderIdent ids
 renderSmallStatement (Import _ ws ns) =
-  "import" <> foldMap renderWhitespace ws <>
+  TkImport () `cons` foldMap renderWhitespace ws <>
   renderCommaSep1 (renderImportAs renderModuleName) ns
 renderSmallStatement (From _ ws1 name ws3 ns) =
-  "from" <> foldMap renderWhitespace ws1 <>
-  renderRelativeModuleName name <> "import" <> foldMap renderWhitespace ws3 <>
+  TkFrom () `cons` foldMap renderWhitespace ws1 <>
+  renderRelativeModuleName name <>
+  singleton (TkImport ()) <> foldMap renderWhitespace ws3 <>
   renderImportTargets ns
 
-renderBlock :: Block v a -> Lines String
+renderBlock :: Block v a -> Lines RenderOutput
 renderBlock =
   foldMap
     (either
        (\(x, y, z) ->
-          OneLine $ foldMap renderWhitespace x <> foldMap renderComment y <> renderNewline z)
+          OneLine $
+          foldMap renderWhitespace x <>
+          maybe mempty (singleton . renderComment) y
+          <> singleton (renderNewline z))
         renderStatement) .
   view _Wrapped
 
-renderCompoundStatement :: CompoundStatement v a -> Lines String
+renderCompoundStatement :: CompoundStatement v a -> Lines RenderOutput
 renderCompoundStatement (Fundef idnt _ ws1 name ws2 params ws3 ws4 nl body) =
   ManyLines firstLine nl restLines
   where
     firstLine =
       renderIndents idnt <>
-      "def" <> foldMap renderWhitespace ws1 <> renderIdent name <>
-      "(" <> foldMap renderWhitespace ws2 <> renderCommaSep renderParam params <>
-      ")" <> foldMap renderWhitespace ws3 <> ":" <> foldMap renderWhitespace ws4
+      singleton (TkDef ()) <> foldMap renderWhitespace ws1 <> renderIdent name <>
+      bracket (foldMap renderWhitespace ws2 <> renderCommaSep renderParam params) <>
+      foldMap renderWhitespace ws3 <> singleton (TkColon ()) <> foldMap renderWhitespace ws4
     restLines = renderBlock body
 renderCompoundStatement (If idnt _ ws1 expr ws3 nl body body') =
   ManyLines firstLine nl restLines
   where
     firstLine =
       renderIndents idnt <>
-      "if" <> foldMap renderWhitespace ws1 <>
-      bracketTuple expr <> ":" <>
-      foldMap renderWhitespace ws3
+      singleton (TkIf ()) <> foldMap renderWhitespace ws1 <>
+      bracketTuple expr <>
+      singleton (TkColon ()) <> foldMap renderWhitespace ws3
     restLines = renderBlock body <> fromMaybe mempty elseLines
     elseLines =
       ManyLines <$>
       fmap
         (\(idnt, ws4, ws5, _, _) ->
            renderIndents idnt <>
-           "else" <> foldMap renderWhitespace ws4 <> ":" <>
-           foldMap renderWhitespace ws5)
+           singleton (TkElse ()) <> foldMap renderWhitespace ws4 <>
+           singleton (TkColon ()) <> foldMap renderWhitespace ws5)
         body' <*>
       fmap (\(_, _, _, nl2, _) -> nl2) body' <*>
       fmap (\(_, _, _, _, body'') -> renderBlock body'') body'
 renderCompoundStatement (While idnt _ ws1 expr ws3 nl body) =
   ManyLines
     (renderIndents idnt <>
-     "while" <> foldMap renderWhitespace ws1 <> bracketTuple expr <>
-     ":" <> foldMap renderWhitespace ws3)
+     singleton (TkWhile ()) <> foldMap renderWhitespace ws1 <> bracketTuple expr <>
+     singleton (TkColon ()) <> foldMap renderWhitespace ws3)
     nl
     (renderBlock body)
 renderCompoundStatement (TryExcept idnt _ a b c d e f g) =
   ManyLines
     (renderIndents idnt <>
-     "try" <> foldMap renderWhitespace a <> ":" <> foldMap renderWhitespace b)
+     singleton (TkTry ()) <> foldMap renderWhitespace a <>
+     singleton (TkColon ()) <> foldMap renderWhitespace b)
     c
     (renderBlock d) <>
   foldMap
     (\(idnt, ws1, eas, ws2, nl, bl) ->
        ManyLines
          (renderIndents idnt <>
-          "except" <> foldMap renderWhitespace ws1 <>
-          renderExceptAs eas <> ":" <> foldMap renderWhitespace ws2)
+          singleton (TkExcept ()) <> foldMap renderWhitespace ws1 <>
+          renderExceptAs eas <>
+          singleton (TkColon ()) <> foldMap renderWhitespace ws2)
          nl
          (renderBlock bl))
     e <>
@@ -365,7 +506,8 @@ renderCompoundStatement (TryExcept idnt _ a b c d e f g) =
     (\(idnt, ws1, ws2, nl, bl) ->
        ManyLines
          (renderIndents idnt <>
-          "else" <> foldMap renderWhitespace ws1 <> ":" <> foldMap renderWhitespace ws2)
+          singleton (TkElse ()) <> foldMap renderWhitespace ws1 <>
+          singleton (TkColon ()) <> foldMap renderWhitespace ws2)
          nl
          (renderBlock bl))
     f <>
@@ -373,55 +515,59 @@ renderCompoundStatement (TryExcept idnt _ a b c d e f g) =
     (\(idnt, ws1, ws2, nl, bl) ->
        ManyLines
          (renderIndents idnt <>
-          "finally" <> foldMap renderWhitespace ws1 <> ":" <> foldMap renderWhitespace ws2)
+          singleton (TkFinally ()) <> foldMap renderWhitespace ws1 <>
+          singleton (TkColon ()) <> foldMap renderWhitespace ws2)
          nl
          (renderBlock bl))
     g
 renderCompoundStatement (TryFinally idnt _ a b c d idnt2 e f g h) =
   ManyLines
     (renderIndents idnt <>
-     "try" <> foldMap renderWhitespace a <> ":" <> foldMap renderWhitespace b)
+     singleton (TkTry ()) <> foldMap renderWhitespace a <>
+     singleton (TkColon ()) <> foldMap renderWhitespace b)
     c
     (renderBlock d) <>
   ManyLines
     (renderIndents idnt2 <>
-     "finally" <> foldMap renderWhitespace e <> ":" <> foldMap renderWhitespace f)
+     singleton (TkFinally ()) <> foldMap renderWhitespace e <>
+     singleton (TkColon ()) <> foldMap renderWhitespace f)
     g
     (renderBlock h)
 renderCompoundStatement (For idnt _ a b c d e f g h) =
   ManyLines
     (renderIndents idnt <>
-     "for" <> foldMap renderWhitespace a <> renderExpr b <>
-     "in" <> foldMap renderWhitespace c <> renderExpr d <> ":" <>
-     foldMap renderWhitespace e)
+     singleton (TkFor ()) <> foldMap renderWhitespace a <> renderExpr b <>
+     singleton (TkIn ()) <> foldMap renderWhitespace c <> renderExpr d <>
+     singleton (TkColon ()) <> foldMap renderWhitespace e)
     f
     (renderBlock g) <>
   foldMap
     (\(idnt, x, y, z, w) ->
        ManyLines
          (renderIndents idnt <>
-          "else" <> foldMap renderWhitespace x <> ":" <> foldMap renderWhitespace y)
+          singleton (TkElse ()) <> foldMap renderWhitespace x <>
+          singleton (TkColon ()) <> foldMap renderWhitespace y)
          z
          (renderBlock w))
     h
 renderCompoundStatement (ClassDef idnt _ a b c d e f) =
   ManyLines
     (renderIndents idnt <>
-     "class" <> foldMap renderWhitespace a <> renderIdent b <>
+     singleton (TkClass ()) <> foldMap renderWhitespace a <>
+     renderIdent b <>
      foldMap
        (\(x, y, z) ->
-          "(" <> foldMap renderWhitespace x <>
-          foldMap (renderCommaSep1 renderArg) y <>
-          ")" <> foldMap renderWhitespace z)
+          bracket (foldMap renderWhitespace x <> foldMap (renderCommaSep1 renderArg) y) <>
+          foldMap renderWhitespace z)
        c <>
-     ":" <> foldMap renderWhitespace d)
+     singleton (TkColon ()) <> foldMap renderWhitespace d)
     e
     (renderBlock f)
 
-renderIndent :: Indent -> String
-renderIndent (MkIndent ws) = foldMap renderWhitespace ws
+renderIndent :: Indent -> RenderOutput
+renderIndent (MkIndent ws) = foldMap renderWhitespace $ toList ws
 
-renderStatement :: Statement v a -> Lines String
+renderStatement :: Statement v a -> Lines RenderOutput
 renderStatement (CompoundStatement c) = renderCompoundStatement c
 renderStatement (SmallStatements idnts s ss sc nl) =
   over firstLine (renderIndents idnts <>) .
@@ -429,12 +575,12 @@ renderStatement (SmallStatements idnts s ss sc nl) =
   renderSmallStatement s <>
   foldMap
     (\(b, c) ->
-       ";" <>
+       TkSemicolon () `cons`
        foldMap renderWhitespace b <>
        renderSmallStatement c)
     ss <>
   foldMap
-    (\b -> ";" <> foldMap renderWhitespace b)
+    (\b -> TkSemicolon () `cons` foldMap renderWhitespace b)
     sc
   where
     f a =
@@ -442,55 +588,67 @@ renderStatement (SmallStatements idnts s ss sc nl) =
         Nothing -> OneLine a
         Just nl' -> ManyLines a nl' NoLines
 
-renderExceptAs :: ExceptAs v a -> String
+renderExceptAs :: ExceptAs v a -> RenderOutput
 renderExceptAs (ExceptAs _ e f) =
   bracketTuple e <>
-  foldMap (\(a, b) -> "as" <> foldMap renderWhitespace a <> renderIdent b) f
+  foldMap (\(a, b) -> TkAs () `cons` foldMap renderWhitespace a <> renderIdent b) f
 
-renderArg :: Arg v a -> String
+renderArg :: Arg v a -> RenderOutput
 renderArg (PositionalArg _ expr) = bracketTuple expr
 renderArg (KeywordArg _ name ws2 expr) =
-  renderIdent name <> "=" <>
+  renderIdent name <> singleton (TkEq ()) <>
   foldMap renderWhitespace ws2 <>
   bracketTuple expr
 renderArg (StarArg _ ws expr) =
-  "*" <>
+  TkStar () `cons`
   foldMap renderWhitespace ws <>
   bracketTuple expr
 renderArg (DoubleStarArg _ ws expr) =
-  "**" <>
+  TkDoubleStar () `cons`
   foldMap renderWhitespace ws <>
   bracketTuple expr
 
-renderParam :: Param v a -> String
-renderParam (PositionalParam _ name) = renderIdent name
-renderParam (StarParam _ ws name) = "*" <> foldMap renderWhitespace ws <> renderIdent name
-renderParam (DoubleStarParam _ ws name) = "**" <> foldMap renderWhitespace ws <> renderIdent name
+renderParam :: Param v a -> RenderOutput
+renderParam (PositionalParam _ name) =
+  renderIdent name
+renderParam (StarParam _ ws name) =
+  TkStar () `cons` foldMap renderWhitespace ws <> renderIdent name
+renderParam (DoubleStarParam _ ws name) =
+  TkDoubleStar () `cons` foldMap renderWhitespace ws <> renderIdent name
 renderParam (KeywordParam _ name ws2 expr) =
-  renderIdent name <> "=" <>
+  renderIdent name <> singleton (TkEq ()) <>
   foldMap renderWhitespace ws2 <> renderExpr expr
 
-renderBinOp :: BinOp a -> String
-renderBinOp (Is _ ws) = "is" <> foldMap renderWhitespace ws
-renderBinOp (Plus _ ws) = "+" <> foldMap renderWhitespace ws
-renderBinOp (Minus _ ws) = "-" <> foldMap renderWhitespace ws
-renderBinOp (Multiply _ ws) = "*" <> foldMap renderWhitespace ws
-renderBinOp (Divide _ ws) = "/" <> foldMap renderWhitespace ws
-renderBinOp (Exp _ ws) = "**" <> foldMap renderWhitespace ws
-renderBinOp (BoolAnd _ ws) = "and" <> foldMap renderWhitespace ws
-renderBinOp (BoolOr _ ws) = "or" <> foldMap renderWhitespace ws
-renderBinOp (Equals _ ws) = "==" <> foldMap renderWhitespace ws
+renderBinOp :: BinOp a -> RenderOutput
+renderBinOp (Is _ ws) = TkIs () `cons` foldMap renderWhitespace ws
+renderBinOp (Plus _ ws) = TkPlus () `cons` foldMap renderWhitespace ws
+renderBinOp (Minus _ ws) = TkMinus () `cons` foldMap renderWhitespace ws
+renderBinOp (Multiply _ ws) = TkStar () `cons` foldMap renderWhitespace ws
+renderBinOp (Divide _ ws) = TkSlash () `cons` foldMap renderWhitespace ws
+renderBinOp (Exp _ ws) = TkDoubleStar () `cons` foldMap renderWhitespace ws
+renderBinOp (BoolAnd _ ws) = TkAnd () `cons` foldMap renderWhitespace ws
+renderBinOp (BoolOr _ ws) = TkOr () `cons` foldMap renderWhitespace ws
+renderBinOp (Equals _ ws) = TkDoubleEq () `cons` foldMap renderWhitespace ws
 
-renderIndents :: Indents a -> String
+renderIndents :: Indents a -> RenderOutput
 renderIndents (Indents is _) = foldMap renderIndent is
 
-renderModule :: Module v a -> String
+renderModule :: Module v a -> RenderOutput
 renderModule (Module ms) =
   foldMap
     (either
        (\(a, b, c) ->
           renderIndents a <>
-          foldMap renderComment b <>
-          foldMap renderNewline c)
-       (renderLines . renderStatement))
+          maybe mempty (singleton . renderComment) b <>
+          maybe mempty (singleton . renderNewline) c)
+       (renderLines id . renderStatement))
     ms
+
+showModule :: Module v a -> String
+showModule = showRenderOutput . renderModule
+
+showStatement :: Statement v a -> String
+showStatement = showRenderOutput . renderLines id . renderStatement
+
+showExpr :: Expr v a -> String
+showExpr = showRenderOutput . renderExpr

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -2,10 +2,13 @@
 {-# language FlexibleInstances, MultiParamTypeClasses #-}
 {-# language LambdaCase #-}
 module Language.Python.Internal.Render
-  ( RenderOutput, showRenderOutput, singleton, cons
-  , showQuoteType, showStringPrefix, showToken
-  , showModule, showStatement, showExpr
+  ( -- * Common Functions
+    showModule, showStatement, showExpr
+    -- * Rendering
+  , RenderOutput, showRenderOutput, singleton, cons
   , renderModule, renderStatement, renderExpr
+    -- * Miscellany
+  , showQuoteType, showStringPrefix, showToken
   , bracket, renderWhitespace, renderCommaSep, renderCommaSep1, renderCommaSep1'
   , renderIdent, renderComment, renderModuleName, renderDot, renderRelativeModuleName
   , renderImportAs, renderImportTargets, renderSmallStatement, renderCompoundStatement

--- a/src/Language/Python/Internal/Syntax/Ident.hs
+++ b/src/Language/Python/Internal/Syntax/Ident.hs
@@ -5,6 +5,7 @@
 module Language.Python.Internal.Syntax.Ident where
 
 import Control.Lens.Lens (Lens, lens)
+import Data.Char (isDigit, isLetter)
 import Data.Coerce (coerce)
 import Data.String (IsString(..))
 
@@ -17,6 +18,18 @@ data Ident (v :: [*]) a
   , _identValue :: String
   , _identWhitespace :: [Whitespace]
   } deriving (Eq, Show, Functor, Foldable, Traversable)
+
+isIdentifierStart :: Char -> Bool
+isIdentifierStart = do
+  a <- isLetter
+  b <- (=='_')
+  pure $ a || b
+
+isIdentifierChar :: Char -> Bool
+isIdentifierChar = do
+  a <- isIdentifierStart
+  b <- isDigit
+  pure $ a || b
 
 instance IsString (Ident '[] ()) where
   fromString s = MkIdent () s []

--- a/src/Language/Python/Internal/Syntax/Keyword.hs
+++ b/src/Language/Python/Internal/Syntax/Keyword.hs
@@ -2,17 +2,49 @@
 module Language.Python.Internal.Syntax.Keyword where
 
 import Control.Lens.Lens (lens)
-import Data.List.NonEmpty (NonEmpty(..))
+import Data.List.NonEmpty (NonEmpty(..), toList)
+import Language.Python.Internal.Render (RenderOutput, singleton)
 import Language.Python.Internal.Syntax.Token
 import Language.Python.Internal.Syntax.Whitespace
+import Language.Python.Internal.Token (PyToken(..))
 
 import qualified Data.List.NonEmpty as NonEmpty
 
 data Keyword = Keyword (NonEmpty Char) [Whitespace]
   deriving (Eq, Show)
 
-keyword :: Keyword -> String
-keyword (Keyword a _) = NonEmpty.toList a
+keyword :: Keyword -> RenderOutput
+keyword (Keyword a _) =
+  case toList a of
+    "if" -> singleton (TkIf ())
+    "else" -> singleton (TkElse ())
+    "while" -> singleton (TkWhile ())
+    "def" -> singleton (TkDef ())
+    "return" -> singleton (TkReturn ())
+    "pass" -> singleton (TkPass ())
+    "break" -> singleton (TkBreak ())
+    "continue" -> singleton (TkContinue ())
+    "True" -> singleton (TkTrue ())
+    "False" -> singleton (TkFalse ())
+    "None" -> singleton (TkNone ())
+    "or" -> singleton (TkOr ())
+    "and" -> singleton (TkAnd ())
+    "is" -> singleton (TkIs ())
+    "not" -> singleton (TkNot ())
+    "global" -> singleton (TkGlobal ())
+    "nonlocal" -> singleton (TkNonlocal ())
+    "defl" -> singleton (TkDel ())
+    "import" -> singleton (TkImport ())
+    "from" -> singleton (TkFrom ())
+    "as" -> singleton (TkAs ())
+    "raise" -> singleton (TkRaise ())
+    "try" -> singleton (TkTry ())
+    "except" -> singleton (TkExcept ())
+    "finally" -> singleton (TkFinally ())
+    "class" -> singleton (TkClass ())
+    "for" -> singleton (TkFor ())
+    "in" -> singleton (TkIn ())
+    str -> singleton (TkIdent str ())
 
 instance Token Keyword Keyword where
   unvalidate = id

--- a/src/Language/Python/Internal/Token.hs
+++ b/src/Language/Python/Internal/Token.hs
@@ -1,0 +1,142 @@
+{-# language DeriveFunctor #-}
+{-# language TemplateHaskell #-}
+module Language.Python.Internal.Token where
+
+import Data.Deriving (deriveEq1)
+
+import Language.Python.Internal.Syntax (StringPrefix(..))
+import Language.Python.Internal.Syntax.Whitespace
+  ( Newline(..) )
+
+data QuoteType = SingleQuote | DoubleQuote
+  deriving (Eq, Show)
+
+data PyToken a
+  = TkIf a
+  | TkElse a
+  | TkWhile a
+  | TkDef a
+  | TkReturn a
+  | TkPass a
+  | TkBreak a
+  | TkContinue a
+  | TkTrue a
+  | TkFalse a
+  | TkOr a
+  | TkAnd a
+  | TkIs a
+  | TkNot a
+  | TkGlobal a
+  | TkDel a
+  | TkImport a
+  | TkFrom a
+  | TkAs a
+  | TkRaise a
+  | TkTry a
+  | TkExcept a
+  | TkFinally a
+  | TkClass a
+  | TkFor a
+  | TkIn a
+  | TkInt Integer a
+  | TkFloat Integer (Maybe Integer) a
+  | TkIdent String a
+  | TkShortString (Maybe StringPrefix) QuoteType String a
+  | TkLongString (Maybe StringPrefix) QuoteType String a
+  | TkSpace a
+  | TkTab a
+  | TkNewline Newline a
+  | TkLeftBracket a
+  | TkRightBracket a
+  | TkLeftParen a
+  | TkRightParen a
+  | TkLeftBrace a
+  | TkRightBrace a
+  | TkLt a
+  | TkLte a
+  | TkEq a
+  | TkDoubleEq a
+  | TkGt a
+  | TkGte a
+  | TkContinued Newline a
+  | TkColon a
+  | TkSemicolon a
+  | TkComma a
+  | TkDot a
+  | TkPlus a
+  | TkMinus a
+  | TkComment String a
+  | TkStar a
+  | TkDoubleStar a
+  | TkSlash a
+  | TkDoubleSlash a
+  | TkPercent a
+  | TkShiftLeft a
+  | TkShiftRight a
+  deriving (Eq, Show, Functor)
+deriveEq1 ''PyToken
+
+pyTokenAnn :: PyToken a -> a
+pyTokenAnn tk =
+  case tk of
+    TkDef a -> a
+    TkReturn a -> a
+    TkPass a -> a
+    TkBreak a -> a
+    TkContinue a -> a
+    TkTrue a -> a
+    TkFalse a -> a
+    TkOr a -> a
+    TkAnd a -> a
+    TkIs a -> a
+    TkNot a -> a
+    TkGlobal a -> a
+    TkDel a -> a
+    TkImport a -> a
+    TkFrom a -> a
+    TkAs a -> a
+    TkRaise a -> a
+    TkTry a -> a
+    TkExcept a -> a
+    TkFinally a -> a
+    TkClass a -> a
+    TkFor a -> a
+    TkIn a -> a
+    TkPlus a -> a
+    TkMinus a -> a
+    TkIf a -> a
+    TkElse a -> a
+    TkWhile a -> a
+    TkInt _ a -> a
+    TkFloat _ _ a -> a
+    TkIdent _ a -> a
+    TkShortString _ _ _ a -> a
+    TkLongString _ _ _ a -> a
+    TkSpace a -> a
+    TkTab a -> a
+    TkNewline _ a -> a
+    TkLeftBracket a -> a
+    TkRightBracket a -> a
+    TkLeftParen a -> a
+    TkRightParen a -> a
+    TkLeftBrace a -> a
+    TkRightBrace a -> a
+    TkLt a -> a
+    TkLte a -> a
+    TkEq a -> a
+    TkDoubleEq a -> a
+    TkGt a -> a
+    TkGte a -> a
+    TkContinued _ a -> a
+    TkColon a -> a
+    TkSemicolon a -> a
+    TkComma a -> a
+    TkDot a -> a
+    TkComment _ a -> a
+    TkStar a -> a
+    TkDoubleStar a -> a
+    TkSlash a -> a
+    TkDoubleSlash a -> a
+    TkPercent a -> a
+    TkShiftLeft a -> a
+    TkShiftRight a -> a

--- a/src/Language/Python/Internal/Token.hs
+++ b/src/Language/Python/Internal/Token.hs
@@ -22,11 +22,13 @@ data PyToken a
   | TkContinue a
   | TkTrue a
   | TkFalse a
+  | TkNone a
   | TkOr a
   | TkAnd a
   | TkIs a
   | TkNot a
   | TkGlobal a
+  | TkNonlocal a
   | TkDel a
   | TkImport a
   | TkFrom a
@@ -86,11 +88,13 @@ pyTokenAnn tk =
     TkContinue a -> a
     TkTrue a -> a
     TkFalse a -> a
+    TkNone a -> a
     TkOr a -> a
     TkAnd a -> a
     TkIs a -> a
     TkNot a -> a
     TkGlobal a -> a
+    TkNonlocal a -> a
     TkDel a -> a
     TkImport a -> a
     TkFrom a -> a

--- a/src/Language/Python/Validate/Syntax.hs
+++ b/src/Language/Python/Validate/Syntax.hs
@@ -432,9 +432,9 @@ validateSmallStatementSyntax (Raise a ws f) =
        traverse
          (\(d, e) ->
             (,) <$
-            validateAdjacentR a (b, renderExpr) (Keyword ('a' :| "s") d, keyword) <*>
+            validateAdjacentR a (b, renderExpr) (Keyword ('f' :| "rom") d, keyword) <*>
             validateWhitespace a d <*
-            validateAdjacentR a (Keyword ('a' :| "s") d, keyword) (e, renderExpr) <*>
+            validateAdjacentR a (Keyword ('f' :| "rom") d, keyword) (e, renderExpr) <*>
             validateExprSyntax e)
          c)
     f

--- a/src/Language/Python/Validate/Syntax.hs
+++ b/src/Language/Python/Validate/Syntax.hs
@@ -164,13 +164,14 @@ validateAdjacentR
      , Token x x', Token y y'
      )
   => a
-  -> (x, x -> String)
-  -> (y, y -> String)
+  -> (x, x -> RenderOutput)
+  -> (y, y -> RenderOutput)
   -> ValidateSyntax e y
 validateAdjacentR ann (a, aStr) (b, bStr)
   | [] <- a ^. getting whitespaceAfter
   , isIdentifier [endChar a, startChar b]
-  = syntaxErrors [_MissingSpacesIn # (ann, aStr a, bStr b)]
+  = syntaxErrors
+    [_MissingSpacesIn # (ann, showRenderOutput $ aStr a, showRenderOutput $ bStr b)]
   | otherwise = pure b
 
 validateAdjacentL
@@ -178,13 +179,14 @@ validateAdjacentL
      , Token x x', Token y y'
      )
   => a
-  -> (x, x -> String)
-  -> (y, y -> String)
+  -> (x, x -> RenderOutput)
+  -> (y, y -> RenderOutput)
   -> ValidateSyntax e x
 validateAdjacentL ann (a, aStr) (b, bStr)
   | [] <- a ^. getting whitespaceAfter
   , isIdentifier [endChar a, startChar b]
-  = syntaxErrors [_MissingSpacesIn # (ann, aStr a, bStr b)]
+  = syntaxErrors
+    [_MissingSpacesIn # (ann, showRenderOutput $ aStr a, showRenderOutput $ bStr b)]
   | otherwise = pure a
 
 validateExprSyntax

--- a/src/Language/Python/Validate/Syntax/Error.hs
+++ b/src/Language/Python/Validate/Syntax/Error.hs
@@ -13,7 +13,6 @@ data SyntaxError (v :: [*]) a
   | UnexpectedDoubleStarParam a String
   | CannotAssignTo a (Expr v a)
   | DuplicateArgument a String
-  | MissingSpacesIn a String String
   | ExpectedNewlineAfter (a, [Whitespace], Statement v a, Maybe Newline)
   | UnexpectedNewline a
   | IdentifierReservedWord a String

--- a/test/Helpers.hs
+++ b/test/Helpers.hs
@@ -6,8 +6,9 @@ import qualified Text.Trifecta as Trifecta
 import Hedgehog
 
 import Language.Python.Internal.Lexer
-  (PyToken, LogicalLine, IndentedLine, Nested, tokenize, logicalLines, indentation, nested)
+  (LogicalLine, IndentedLine, Nested, tokenize, logicalLines, indentation, nested)
 import Language.Python.Internal.Parse (Parser, runParser)
+import Language.Python.Internal.Token (PyToken)
 
 doTokenize :: Monad m => String -> PropertyT m [PyToken Trifecta.Caret]
 doTokenize str = do

--- a/test/LexerParser.hs
+++ b/test/LexerParser.hs
@@ -30,6 +30,7 @@ lexerParserTests =
   , ("Test full trip 10", test_fulltrip_10)
   , ("Test full trip 11", test_fulltrip_11)
   , ("Test full trip 12", test_fulltrip_12)
+  , ("Test full trip 13", test_fulltrip_13)
   ]
 
 test_fulltrip_1 :: Property
@@ -37,21 +38,21 @@ test_fulltrip_1 =
   withTests 1 . property $ do
     let str = "def a(x, y=2, *z, **w):\n   return 2 + 3"
     a <- doToPython statement str
-    renderLines (renderStatement a) === str
+    showStatement a === str
 
 test_fulltrip_2 :: Property
 test_fulltrip_2 =
   withTests 1 . property $ do
     let str = "(   1\n       *\n  3\n    )"
     a <- doToPython (expr space) str
-    renderExpr a === str
+    showExpr a === str
 
 test_fulltrip_3 :: Property
 test_fulltrip_3 =
   withTests 1 . property $ do
     let str = "pass;"
     a <- doToPython statement str
-    renderLines (renderStatement a) === str
+    showStatement a === str
 
 test_fulltrip_4 :: Property
 test_fulltrip_4 =
@@ -72,7 +73,7 @@ test_fulltrip_4 =
     annotateShow nst
 
     a <- doToPython statement str
-    renderLines (renderStatement a) === str
+    showStatement a === str
 
 test_fulltrip_5 :: Property
 test_fulltrip_5 =
@@ -93,7 +94,7 @@ test_fulltrip_5 =
     annotateShow nst
 
     a <- doToPython statement str
-    renderLines (renderStatement a) === str
+    showStatement a === str
 
 test_fulltrip_6 :: Property
 test_fulltrip_6 =
@@ -114,7 +115,7 @@ test_fulltrip_6 =
     annotateShow nst
 
     a <- doToPython module_ str
-    renderModule a === str
+    showModule a === str
 
 test_fulltrip_7 :: Property
 test_fulltrip_7 =
@@ -134,7 +135,7 @@ test_fulltrip_7 =
     annotateShow nst
 
     a <- doToPython module_ str
-    renderModule a === str
+    showModule a === str
 
 test_fulltrip_8 :: Property
 test_fulltrip_8 =
@@ -154,7 +155,7 @@ test_fulltrip_8 =
     annotateShow nst
 
     a <- doToPython module_ str
-    renderModule a === str
+    showModule a === str
 
 test_fulltrip_9 :: Property
 test_fulltrip_9 =
@@ -178,7 +179,7 @@ test_fulltrip_9 =
     a <- doParse module_ nst
     annotateShow a
 
-    renderModule a === str
+    showModule a === str
 
 test_fulltrip_10 :: Property
 test_fulltrip_10 =
@@ -214,7 +215,7 @@ test_fulltrip_10 =
     a <- doParse module_ nst
     annotateShow $! a
 
-    renderModule a === str
+    showModule a === str
 
 test_fulltrip_11 :: Property
 test_fulltrip_11 =
@@ -245,7 +246,7 @@ test_fulltrip_11 =
     a <- doParse module_ nst
     annotateShow $! a
 
-    renderModule a === str
+    showModule a === str
 
 test_fulltrip_12 :: Property
 test_fulltrip_12 =
@@ -277,7 +278,41 @@ test_fulltrip_12 =
     a <- doParse module_ nst
     annotateShow $! a
 
-    renderModule a === str
+    showModule a === str
+
+test_fulltrip_13 :: Property
+test_fulltrip_13 =
+  withTests 1 . property $ do
+    let
+      str =
+        unlines
+        [ "if []:"
+        , " False"
+        , " def a():"
+        , "  pass"
+        , "  pass"
+        , ""
+        , "else:"
+        , " pass"
+        , " pass"
+        ]
+
+    tks <- doTokenize str
+    annotateShow $! tks
+
+    let lls = logicalLines tks
+    annotateShow $! lls
+
+    ils <- doIndentation lls
+    annotateShow $! ils
+
+    nst <- doNested ils
+    annotateShow $! nst
+
+    a <- doParse module_ nst
+    annotateShow $! a
+
+    showModule a === str
 
 parseTab :: Parser ann Whitespace
 parseTab = do

--- a/test/LexerParser.hs
+++ b/test/LexerParser.hs
@@ -9,6 +9,7 @@ import Language.Python.Internal.Lexer
 import Language.Python.Internal.Parse
 import Language.Python.Internal.Render
 import Language.Python.Internal.Syntax.Whitespace
+import Language.Python.Internal.Token
 
 import Helpers (doToPython, doParse, doNested, doTokenize, doIndentation)
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -89,13 +89,8 @@ syntax_expr path =
         Failure errs -> annotateShow errs $> False
         Success res ->
           case validateExprSyntax' res of
-            Failure errs' ->
-              let
-                errs'' = filter (hasn't _MissingSpacesIn) errs'
-              in
-                if null errs''
-                then pure True
-                else annotateShow errs'' $> False
+            Failure [] -> pure True
+            Failure errs'' -> annotateShow errs'' $> False
             Success res' -> pure True
     annotate rex
     runPython3
@@ -113,13 +108,8 @@ syntax_statement path =
         Failure errs -> annotateShow errs $> False
         Success res ->
           case validateStatementSyntax' res of
-            Failure errs' ->
-              let
-                errs'' = filter (hasn't _MissingSpacesIn) errs'
-              in
-                if null errs''
-                then pure True
-                else annotateShow errs'' $> False
+            Failure [] -> pure True
+            Failure errs'' -> annotateShow errs'' $> False
             Success res' -> pure True
     annotate rst
     runPython3 path shouldSucceed rst
@@ -134,13 +124,8 @@ syntax_module path =
         Failure errs -> annotateShow errs $> False
         Success res ->
           case validateModuleSyntax' res of
-            Failure errs' ->
-              let
-                errs'' = filter (hasn't _MissingSpacesIn) errs'
-              in
-                if null errs''
-                then pure True
-                else annotateShow errs'' $> False
+            Failure [] -> pure True
+            Failure errs'' -> annotateShow errs'' $> False
             Success res' -> pure True
     annotate rst
     runPython3 path shouldSucceed rst

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -83,7 +83,7 @@ syntax_expr :: FilePath -> Property
 syntax_expr path =
   property $ do
     ex <- forAll $ Gen.resize 300 General.genExpr
-    let rex = renderExpr ex
+    let rex = showExpr ex
     shouldSucceed <-
       case validateExprIndentation' ex of
         Failure errs -> annotateShow errs $> False
@@ -107,7 +107,7 @@ syntax_statement :: FilePath -> Property
 syntax_statement path =
   property $ do
     st <- forAll $ Gen.resize 300 General.genStatement
-    let rst = renderLines $ renderStatement st
+    let rst = showStatement st
     shouldSucceed <-
       case validateStatementIndentation' st of
         Failure errs -> annotateShow errs $> False
@@ -128,7 +128,7 @@ syntax_module :: FilePath -> Property
 syntax_module path =
   property $ do
     st <- forAll $ Gen.resize 300 General.genModule
-    let rst = renderModule st
+    let rst = showModule st
     shouldSucceed <-
       case validateModuleIndentation' st of
         Failure errs -> annotateShow errs $> False
@@ -154,48 +154,48 @@ correct_syntax_expr path =
       Success res ->
         case validateExprSyntax' res of
           Failure errs' -> annotateShow errs' *> failure
-          Success res' -> runPython3 path True (renderExpr ex)
+          Success res' -> runPython3 path True (showExpr ex)
 
 correct_syntax_statement :: FilePath -> Property
 correct_syntax_statement path =
   property $ do
     st <- forAll $ evalStateT Correct.genStatement Correct.initialGenState
-    annotate $ renderLines (renderStatement st)
+    annotate $ showStatement st
     case validateStatementIndentation' st of
       Failure errs -> annotateShow errs *> failure
       Success res ->
         case validateStatementSyntax' res of
           Failure errs' -> annotateShow errs' *> failure
-          Success res' -> runPython3 path True (renderLines $ renderStatement st)
+          Success res' -> runPython3 path True $ showStatement st
 
 expr_printparseprint_print :: Property
 expr_printparseprint_print =
   property $ do
     ex <- forAll Correct.genExpr
-    annotate (renderExpr ex)
+    annotate (showExpr ex)
     case validateExprIndentation' ex of
       Failure errs -> annotateShow errs *> failure
       Success res ->
         case validateExprSyntax' res of
           Failure errs' -> annotateShow errs' *> failure
           Success res' -> do
-            py <- doToPython (expr space) (renderExpr res')
-            renderExpr (res' ^. unvalidated) === renderExpr (res $> ())
+            py <- doToPython (expr space) (showExpr res')
+            showExpr (res' ^. unvalidated) === showExpr (res $> ())
 
 statement_printparseprint_print :: Property
 statement_printparseprint_print =
   property $ do
     st <- forAll $ evalStateT Correct.genStatement Correct.initialGenState
-    annotate (renderLines $ renderStatement st)
+    annotate $ showStatement st
     case validateStatementIndentation' st of
       Failure errs -> annotateShow errs *> failure
       Success res ->
         case validateStatementSyntax' res of
           Failure errs' -> annotateShow errs' *> failure
           Success res' -> do
-            py <- doToPython statement . renderLines $ renderStatement res'
-            renderLines (renderStatement (res' ^. unvalidated)) ===
-              renderLines (renderStatement (py $> ()))
+            py <- doToPython statement $ showStatement res'
+            showStatement (res' ^. unvalidated) ===
+              showStatement (py $> ())
 
 main = do
   checkParallel lexerParserTests

--- a/test/Roundtrip.hs
+++ b/test/Roundtrip.hs
@@ -11,7 +11,7 @@ import System.FilePath ((</>))
 import Text.Trifecta (Caret)
 
 import Language.Python.Internal.Parse (module_)
-import Language.Python.Internal.Render (renderModule)
+import Language.Python.Internal.Render (showModule)
 import Language.Python.Validate.Indentation
   (Indentation, runValidateIndentation, validateModuleIndentation)
 import Language.Python.Validate.Indentation.Error (IndentationError)
@@ -42,4 +42,4 @@ doRoundtrip name =
       Success res ->
         case runValidateSyntax initialSyntaxContext [] (validateModuleSyntax res) of
           Failure errs' -> annotateShow (errs' :: [SyntaxError '[Indentation] Caret]) *> failure
-          Success _ -> renderModule py === file
+          Success _ -> showModule py === file


### PR DESCRIPTION
"Token munging" occurs when two adjacent tokens would be parsed as a single token. For example, `[TkNot, TkNot]` represents the string "notnot", which would be parsed as `[TkIdent "notnot"]`.

I haven't had a good way to deal with this until now. This morning Dave suggested to just insert the minimal number of tokens required to prevent or nullify munging. So now `[TkNot, TkNot]` will be printed to `not not`, and `[TkContinue CR, TkNewline LF]` (which previously would have been read back as `[TkContinue CRLF]`) is printed as `[TkContinue CRLF, TkNewline LF]`. It turns out that this behaviour doesn't impact the laws of `parse` and `print`; it only prevents silly things.

Fixes #45 