### PR TITLE
Adjust some bounds and fix build on GHC 8.0

### DIFF
--- a/hpython.cabal
+++ b/hpython.cabal
@@ -51,18 +51,19 @@ library
                      , Language.Python.Validate.Indentation
                      , Language.Python.Validate.Indentation.Error
   build-depends:       base >=4.9 && <5
-                     , digit >=0.6
+                     , bifunctors
+                     , digit >=0.6 && < 0.7
                      , dlist >=0.8 && <0.9
                      , lens
                      , type-level-sets >=0.8.6.0
                      , parsers
-                     , megaparsec >=6.3 && <6.4
+                     , megaparsec >=6.3 && <7.1
                      , fingertree >=0.1 && <0.2
                      , mtl
                      , bytestring-trie >=0.2
-                     , containers >=0.5 && <0.6
-                     , deriving-compat >=0.4 && <0.5
-                     , semigroupoids >=5.2.2 && <5.3
+                     , containers >=0.5.8 && <0.7
+                     , deriving-compat >=0.4 && <0.6
+                     , semigroupoids >=5.2.2 && <5.4
                      , text >=1.2 && <1.3
                      , these >=0.7.4 && <0.7.5
                      , parsers-megaparsec >=0.1 && <0.2


### PR DESCRIPTION
Tighten lower bound on containers due to use of (!?)
Loosen some upper bounds indicated by `cabal outdated`
Add bifunctors dependency to fix the build on GHC 8.0