### PR TITLE
Make optics external rather than internal

### DIFF
--- a/example/FixMutableDefaultArguments.hs
+++ b/example/FixMutableDefaultArguments.hs
@@ -8,7 +8,7 @@ import Control.Lens.Setter ((.~))
 import Data.Function ((&))
 import Data.Semigroup ((<>))
 
-import Language.Python.Internal.Optics
+import Language.Python.Optics
 import Language.Python.Internal.Syntax
 import Language.Python.Syntax
 

--- a/example/Indentation.hs
+++ b/example/Indentation.hs
@@ -5,7 +5,7 @@ import Control.Lens.Setter ((.~))
 import Control.Lens.Plated (transform)
 import GHC.Natural (Natural)
 
-import Language.Python.Internal.Optics
+import Language.Python.Optics
 import Language.Python.Internal.Syntax
 
 indentSpaces :: Natural -> Statement '[] a -> Statement '[] a

--- a/example/OptimizeTailRecursion.hs
+++ b/example/OptimizeTailRecursion.hs
@@ -17,7 +17,7 @@ import Data.Function ((&))
 import Data.Semigroup ((<>))
 
 
-import Language.Python.Internal.Optics
+import Language.Python.Optics
 import Language.Python.Internal.Syntax
 import Language.Python.Syntax
 

--- a/hpython.cabal
+++ b/hpython.cabal
@@ -58,8 +58,6 @@ library
   exposed-modules:     Data.Type.Set
                      , Data.Validate.Monadic
                      , Language.Python.Internal.Lexer
-                     , Language.Python.Internal.Optics
-                     , Language.Python.Internal.Optics.Validated
                      , Language.Python.Internal.Parse
                      , Language.Python.Internal.Render
                      , Language.Python.Internal.Render.Correction
@@ -80,6 +78,8 @@ library
                      , Language.Python.Internal.Syntax.Strings
                      , Language.Python.Internal.Syntax.UnOp
                      , Language.Python.Internal.Syntax.Whitespace
+                     , Language.Python.Optics
+                     , Language.Python.Optics.Validated
                      , Language.Python.Parse
                      , Language.Python.Syntax
                      , Language.Python.Syntax.Types

--- a/src/Language/Python/Internal/Syntax/Expr.hs
+++ b/src/Language/Python/Internal/Syntax/Expr.hs
@@ -28,7 +28,7 @@ import Data.String (IsString(..))
 import GHC.Generics (Generic)
 import Unsafe.Coerce (unsafeCoerce)
 
-import Language.Python.Internal.Optics.Validated (Validated(..))
+import Language.Python.Optics.Validated (Validated(..))
 import Language.Python.Internal.Syntax.BinOp
 import Language.Python.Internal.Syntax.CommaSep
 import Language.Python.Internal.Syntax.Ident

--- a/src/Language/Python/Internal/Syntax/Ident.hs
+++ b/src/Language/Python/Internal/Syntax/Ident.hs
@@ -7,7 +7,7 @@ import Control.Lens.Lens (Lens, lens)
 import Data.Char (isDigit, isLetter)
 import Data.String (IsString(..))
 
-import Language.Python.Internal.Optics.Validated (Validated)
+import Language.Python.Optics.Validated (Validated)
 import Language.Python.Internal.Syntax.Whitespace
 
 data Ident (v :: [*]) a

--- a/src/Language/Python/Internal/Syntax/Statement.hs
+++ b/src/Language/Python/Internal/Syntax/Statement.hs
@@ -24,7 +24,7 @@ import Data.Monoid ((<>))
 import GHC.Generics (Generic)
 import Unsafe.Coerce (unsafeCoerce)
 
-import Language.Python.Internal.Optics.Validated
+import Language.Python.Optics.Validated
 import Language.Python.Internal.Syntax.AugAssign
 import Language.Python.Internal.Syntax.CommaSep
 import Language.Python.Internal.Syntax.Comment

--- a/src/Language/Python/Optics.hs
+++ b/src/Language/Python/Optics.hs
@@ -1,7 +1,7 @@
 {-# language DataKinds #-}
 {-# language PolyKinds #-}
 {-# language LambdaCase #-}
-module Language.Python.Internal.Optics where
+module Language.Python.Optics where
 
 import Control.Lens.Fold (Fold)
 import Control.Lens.Getter ((^.), view)
@@ -13,7 +13,7 @@ import Control.Lens.Prism (Prism, _Right, prism)
 import Data.Coerce (coerce)
 import Data.Function ((&))
 
-import Language.Python.Internal.Optics.Validated (unvalidated)
+import Language.Python.Optics.Validated (unvalidated)
 import Language.Python.Internal.Syntax
 import Language.Python.Syntax.Types
 

--- a/src/Language/Python/Optics/Validated.hs
+++ b/src/Language/Python/Optics/Validated.hs
@@ -1,5 +1,5 @@
 {-# language DataKinds, PolyKinds, DefaultSignatures #-}
-module Language.Python.Internal.Optics.Validated where
+module Language.Python.Optics.Validated where
 
 import Control.Lens.Getter (Getter, to)
 import Data.Coerce (Coercible, coerce)

--- a/src/Language/Python/Syntax.hs
+++ b/src/Language/Python/Syntax.hs
@@ -351,7 +351,7 @@ import Data.List.NonEmpty (NonEmpty(..))
 import Data.Maybe (fromMaybe)
 import Data.Semigroup ((<>))
 
-import Language.Python.Internal.Optics
+import Language.Python.Optics
 import Language.Python.Internal.Syntax hiding (Fundef, While, Call)
 import Language.Python.Syntax.Types
 

--- a/src/Language/Python/Validate/Indentation.hs
+++ b/src/Language/Python/Validate/Indentation.hs
@@ -40,8 +40,8 @@ import Data.Validation (Validation(..))
 import Data.Validate.Monadic (ValidateM(..), liftVM0, errorVM, errorVM1)
 import qualified Data.List.NonEmpty as NonEmpty
 
-import Language.Python.Internal.Optics
-import Language.Python.Internal.Optics.Validated (unvalidated)
+import Language.Python.Optics
+import Language.Python.Optics.Validated (unvalidated)
 import Language.Python.Internal.Syntax
 import Language.Python.Validate.Indentation.Error
 

--- a/src/Language/Python/Validate/Scope.hs
+++ b/src/Language/Python/Validate/Scope.hs
@@ -69,8 +69,8 @@ import Unsafe.Coerce (unsafeCoerce)
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map.Strict as Map
 
-import Language.Python.Internal.Optics
-import Language.Python.Internal.Optics.Validated (unvalidated)
+import Language.Python.Optics
+import Language.Python.Optics.Validated (unvalidated)
 import Language.Python.Internal.Syntax
 import Language.Python.Validate.Scope.Error
 

--- a/src/Language/Python/Validate/Syntax.hs
+++ b/src/Language/Python/Validate/Syntax.hs
@@ -73,8 +73,8 @@ import Unsafe.Coerce (unsafeCoerce)
 
 import qualified Data.List.NonEmpty as NonEmpty
 
-import Language.Python.Internal.Optics
-import Language.Python.Internal.Optics.Validated (unvalidated)
+import Language.Python.Optics
+import Language.Python.Optics.Validated (unvalidated)
 import Language.Python.Internal.Syntax
 import Language.Python.Validate.Indentation
 import Language.Python.Validate.Syntax.Error

--- a/test/Generators/Correct.hs
+++ b/test/Generators/Correct.hs
@@ -29,7 +29,7 @@ import qualified Data.List.NonEmpty as NonEmpty
 import GHC.Stack
 
 import Language.Python.Syntax.Types (spType)
-import Language.Python.Internal.Optics
+import Language.Python.Optics
 import Language.Python.Internal.Syntax
 
 import Generators.Common

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -3,7 +3,7 @@
 {-# language OverloadedStrings #-}
 module Main where
 
-import Language.Python.Internal.Optics.Validated (unvalidated)
+import Language.Python.Optics.Validated (unvalidated)
 import Language.Python.Internal.Render
 import Language.Python.Internal.Syntax
 import Language.Python.Parse (parseStatement, parseExpr, parseExprList)

--- a/test/Optics.hs
+++ b/test/Optics.hs
@@ -12,7 +12,7 @@ import qualified Data.Text.IO as Text
 import Language.Python.Parse (parseModule)
 import Language.Python.Internal.Render (showModule)
 import Language.Python.Internal.Syntax (Whitespace(..), _Statements)
-import Language.Python.Internal.Optics (_Indent)
+import Language.Python.Optics (_Indent)
 
 opticsTests :: Group
 opticsTests = $$discover


### PR DESCRIPTION
I'd like to start focusing on slicing up hpython into external and internal API. I think a lot of things are internal at the moment that are necessary for anyone wanting to work with hpython. The most obvious of these is optics.