### PR TITLE
Improved representation of octal PyChars

### DIFF
--- a/src/Language/Python/Internal/Lexer.hs
+++ b/src/Language/Python/Internal/Lexer.hs
@@ -156,7 +156,15 @@ stringChar =
        replicateM 4 parseHeXaDeCiMaL)
 
     hexChar = Char_hex <$ char 'x' <*> parseHeXaDeCiMaL <*> parseHeXaDeCiMaL
-    octChar = Char_octal <$> parseOctal <*> parseOctal <*> parseOctal
+    octChar =
+      (\a b c ->
+         maybe
+           (Char_octal1 a)
+           (\b' -> maybe (Char_octal2 a b') (Char_octal3 a b') c)
+           b) <$>
+      parseOctal <*>
+      optional parseOctal <*>
+      optional parseOctal
 
 number :: (CharParsing m, Monad m) => m (a -> PyToken a)
 number = do

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -164,7 +164,15 @@ renderPyCharsBytes qt st =
       case s of
         [] -> ""
         Char_newline : cs -> "\\newline" <> go cs
-        Char_octal a b c : cs ->
+        Char_octal1 a  : cs ->
+          "\\" <>
+          [charOctal # a] <>
+          go cs
+        Char_octal2 a b : cs ->
+          "\\" <>
+          [charOctal # a, charOctal # b] <>
+          go cs
+        Char_octal3 a b c : cs ->
           "\\" <>
           [charOctal # a, charOctal # b, charOctal # c] <>
           go cs
@@ -383,7 +391,15 @@ renderPyChars qt st =
       case s of
         [] -> ""
         Char_newline : cs -> "\\newline" <> go cs
-        Char_octal a b c : cs ->
+        Char_octal1 a : cs ->
+          "\\" <>
+          [charOctal # a] <>
+          go cs
+        Char_octal2 a b : cs ->
+          "\\" <>
+          [charOctal # a, charOctal # b] <>
+          go cs
+        Char_octal3 a b c : cs ->
           "\\" <>
           [charOctal # a, charOctal # b, charOctal # c] <>
           go cs

--- a/src/Language/Python/Internal/Syntax/Strings.hs
+++ b/src/Language/Python/Internal/Syntax/Strings.hs
@@ -116,7 +116,9 @@ instance HasTrailingWhitespace (StringLiteral a) where
 
 data PyChar
   = Char_newline
-  | Char_octal OctDigit OctDigit OctDigit
+  | Char_octal1 OctDigit
+  | Char_octal2 OctDigit OctDigit
+  | Char_octal3 OctDigit OctDigit OctDigit
   | Char_hex HeXDigit HeXDigit
   | Char_uni16
       HeXDigit
@@ -149,7 +151,9 @@ isEscape :: PyChar -> Bool
 isEscape c =
   case c of
     Char_newline -> True
-    Char_octal{} -> True
+    Char_octal1{} -> True
+    Char_octal2{} -> True
+    Char_octal3{} -> True
     Char_hex{} -> True
     Char_uni16{} -> True
     Char_uni32{} -> True

--- a/test/Generators/Common.hs
+++ b/test/Generators/Common.hs
@@ -525,7 +525,12 @@ genPyChar :: MonadGen m => m Char -> m PyChar
 genPyChar mlit =
   Gen.choice
   [ pure Char_newline
-  , Char_octal <$>
+  , Char_octal1 <$>
+    Gen.element enumOctal
+  , Char_octal2 <$>
+    Gen.element enumOctal <*>
+    Gen.element enumOctal
+  , Char_octal3 <$>
     Gen.element enumOctal <*>
     Gen.element enumOctal <*>
     Gen.element enumOctal

--- a/test/LexerParser.hs
+++ b/test/LexerParser.hs
@@ -293,3 +293,17 @@ prop_fulltrip_23 =
     let str = "None,*None"
 
     void . shouldBeSuccess $ parseModule "test" str
+
+prop_fulltrip_24 :: Property
+prop_fulltrip_24 =
+  withTests 1 . property $ do
+    let str = "'\1'"
+
+    void . shouldBeSuccess $ parseModule "test" str
+
+prop_fulltrip_25 :: Property
+prop_fulltrip_25 =
+  withTests 1 . property $ do
+    let str = "'\11'"
+
+    void . shouldBeSuccess $ parseModule "test" str


### PR DESCRIPTION
Octal characters can be formed with 1, 2, or 3 digits trailing a backslash. Previously I assumed it was always exactly 3.