### PR TITLE
Split AugAssignOp out of AugAssign

### DIFF
--- a/src/Language/Python/Internal/Parse.hs
+++ b/src/Language/Python/Internal/Parse.hs
@@ -738,67 +738,67 @@ smallStatement =
       token space (\case; TkContinue{} -> True; _ -> False) "continue"
 
     augAssign =
-      (\(tk, s) -> PlusEq (pyTokenAnn tk) s) <$>
+      (\(tk, s) -> MkAugAssign PlusEq (pyTokenAnn tk) s) <$>
       token space (\case; TkPlusEq{} -> True; _ -> False) "+="
 
       <|>
 
-      (\(tk, s) -> MinusEq (pyTokenAnn tk) s) <$>
+      (\(tk, s) -> MkAugAssign MinusEq (pyTokenAnn tk) s) <$>
       token space (\case; TkMinusEq{} -> True; _ -> False) "-="
 
       <|>
 
-      (\(tk, s) -> AtEq (pyTokenAnn tk) s) <$>
+      (\(tk, s) -> MkAugAssign AtEq (pyTokenAnn tk) s) <$>
       token space (\case; TkAtEq{} -> True; _ -> False) "@="
 
       <|>
 
-      (\(tk, s) -> StarEq (pyTokenAnn tk) s) <$>
+      (\(tk, s) -> MkAugAssign StarEq (pyTokenAnn tk) s) <$>
       token space (\case; TkStarEq{} -> True; _ -> False) "*="
 
       <|>
 
-      (\(tk, s) -> SlashEq (pyTokenAnn tk) s) <$>
+      (\(tk, s) -> MkAugAssign SlashEq (pyTokenAnn tk) s) <$>
       token space (\case; TkSlashEq{} -> True; _ -> False) "/="
 
       <|>
 
-      (\(tk, s) -> PercentEq (pyTokenAnn tk) s) <$>
+      (\(tk, s) -> MkAugAssign PercentEq (pyTokenAnn tk) s) <$>
       token space (\case; TkPercentEq{} -> True; _ -> False) "%="
 
       <|>
 
-      (\(tk, s) -> AmpersandEq (pyTokenAnn tk) s) <$>
+      (\(tk, s) -> MkAugAssign AmpersandEq (pyTokenAnn tk) s) <$>
       token space (\case; TkAmpersandEq{} -> True; _ -> False) "&="
 
       <|>
 
-      (\(tk, s) -> PipeEq (pyTokenAnn tk) s) <$>
+      (\(tk, s) -> MkAugAssign PipeEq (pyTokenAnn tk) s) <$>
       token space (\case; TkPipeEq{} -> True; _ -> False) "|="
 
       <|>
 
-      (\(tk, s) -> CaretEq (pyTokenAnn tk) s) <$>
+      (\(tk, s) -> MkAugAssign CaretEq (pyTokenAnn tk) s) <$>
       token space (\case; TkCaretEq{} -> True; _ -> False) "^="
 
       <|>
 
-      (\(tk, s) -> ShiftLeftEq (pyTokenAnn tk) s) <$>
+      (\(tk, s) -> MkAugAssign ShiftLeftEq (pyTokenAnn tk) s) <$>
       token space (\case; TkShiftLeftEq{} -> True; _ -> False) "<<="
 
       <|>
 
-      (\(tk, s) -> ShiftRightEq (pyTokenAnn tk) s) <$>
+      (\(tk, s) -> MkAugAssign ShiftRightEq (pyTokenAnn tk) s) <$>
       token space (\case; TkShiftRightEq{} -> True; _ -> False) ">>="
 
       <|>
 
-      (\(tk, s) -> DoubleStarEq (pyTokenAnn tk) s) <$>
+      (\(tk, s) -> MkAugAssign DoubleStarEq (pyTokenAnn tk) s) <$>
       token space (\case; TkDoubleStarEq{} -> True; _ -> False) "**="
 
       <|>
 
-      (\(tk, s) -> DoubleSlashEq (pyTokenAnn tk) s) <$>
+      (\(tk, s) -> MkAugAssign DoubleSlashEq (pyTokenAnn tk) s) <$>
       token space (\case; TkDoubleSlashEq{} -> True; _ -> False) "//="
 
     exprOrAssignSt =

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -879,20 +879,20 @@ renderImportTargets (ImportSomeParens _ ws1 ts ws2) =
 
 renderAugAssign :: AugAssign a -> RenderOutput
 renderAugAssign aa =
-  (case aa of
-     PlusEq{} -> TkPlusEq ()
-     MinusEq{} -> TkMinusEq ()
-     StarEq{} -> TkStarEq ()
-     AtEq{} -> TkAtEq ()
-     SlashEq{} -> TkSlashEq ()
-     PercentEq{} -> TkPercentEq ()
-     AmpersandEq{} -> TkAmpersandEq ()
-     PipeEq{} -> TkPipeEq ()
-     CaretEq{} -> TkCaretEq ()
-     ShiftLeftEq{} -> TkShiftLeftEq ()
-     ShiftRightEq{} -> TkShiftRightEq ()
-     DoubleStarEq{} -> TkDoubleStarEq ()
-     DoubleSlashEq{} -> TkDoubleSlashEq ()) `cons`
+  (case _augAssignType aa of
+     PlusEq -> TkPlusEq ()
+     MinusEq -> TkMinusEq ()
+     StarEq -> TkStarEq ()
+     AtEq -> TkAtEq ()
+     SlashEq -> TkSlashEq ()
+     PercentEq -> TkPercentEq ()
+     AmpersandEq -> TkAmpersandEq ()
+     PipeEq -> TkPipeEq ()
+     CaretEq -> TkCaretEq ()
+     ShiftLeftEq -> TkShiftLeftEq ()
+     ShiftRightEq -> TkShiftRightEq ()
+     DoubleStarEq -> TkDoubleStarEq ()
+     DoubleSlashEq -> TkDoubleSlashEq ()) `cons`
   foldMap renderWhitespace (_augAssignWhitespace aa)
 
 renderSmallStatement :: SmallStatement v a -> RenderOutput

--- a/src/Language/Python/Internal/Syntax/AugAssign.hs
+++ b/src/Language/Python/Internal/Syntax/AugAssign.hs
@@ -15,7 +15,6 @@ import Control.Lens.Lens (lens)
 
 import Language.Python.Internal.Syntax.Whitespace
 
-
 -- | Augmented assignments (PEP 203), such as:
 --
 -- @
@@ -27,57 +26,13 @@ import Language.Python.Internal.Syntax.Whitespace
 -- @
 -- x <<= 8
 -- @
+--
+-- An 'AugAssign' has an 'AugAssignOp' and trailing whitespace. There is an
+-- optional annotation, which can simply be @()@ if no annotation is desired.
 data AugAssign a
-  = PlusEq
-  { _augAssignAnn :: a
-  , _augAssignWhitespace :: [Whitespace]
-  }
-  | MinusEq
-  { _augAssignAnn :: a
-  , _augAssignWhitespace :: [Whitespace]
-  }
-  | StarEq
-  { _augAssignAnn :: a
-  , _augAssignWhitespace :: [Whitespace]
-  }
-  | AtEq
-  { _augAssignAnn :: a
-  , _augAssignWhitespace :: [Whitespace]
-  }
-  | SlashEq
-  { _augAssignAnn :: a
-  , _augAssignWhitespace :: [Whitespace]
-  }
-  | PercentEq
-  { _augAssignAnn :: a
-  , _augAssignWhitespace :: [Whitespace]
-  }
-  | AmpersandEq
-  { _augAssignAnn :: a
-  , _augAssignWhitespace :: [Whitespace]
-  }
-  | PipeEq
-  { _augAssignAnn :: a
-  , _augAssignWhitespace :: [Whitespace]
-  }
-  | CaretEq
-  { _augAssignAnn :: a
-  , _augAssignWhitespace :: [Whitespace]
-  }
-  | ShiftLeftEq
-  { _augAssignAnn :: a
-  , _augAssignWhitespace :: [Whitespace]
-  }
-  | ShiftRightEq
-  { _augAssignAnn :: a
-  , _augAssignWhitespace :: [Whitespace]
-  }
-  | DoubleStarEq
-  { _augAssignAnn :: a
-  , _augAssignWhitespace :: [Whitespace]
-  }
-  | DoubleSlashEq
-  { _augAssignAnn :: a
+  = MkAugAssign
+  { _augAssignType :: AugAssignOp
+  , _augAssignAnn :: a
   , _augAssignWhitespace :: [Whitespace]
   }
   deriving (Eq, Show, Functor, Foldable, Traversable)
@@ -85,3 +40,20 @@ data AugAssign a
 instance HasTrailingWhitespace (AugAssign a) where
   trailingWhitespace =
     lens _augAssignWhitespace (\a b -> a { _augAssignWhitespace = b })
+
+-- | The operation of an @AugAssign@. 'PlusEq' for '+=', 'PipeEq' for @|=@, etc.
+data AugAssignOp
+  = PlusEq
+  | MinusEq
+  | StarEq
+  | AtEq
+  | SlashEq
+  | PercentEq
+  | AmpersandEq
+  | PipeEq
+  | CaretEq
+  | ShiftLeftEq
+  | ShiftRightEq
+  | DoubleStarEq
+  | DoubleSlashEq
+  deriving (Eq, Show)

--- a/src/Language/Python/Syntax.hs
+++ b/src/Language/Python/Syntax.hs
@@ -1207,12 +1207,12 @@ longStr_ s =
   String () . pure $
   StringLiteral () Nothing LongString DoubleQuote (Char_lit <$> s) []
 
-mkAugAssign :: ([Whitespace] -> AugAssign ()) -> Raw Expr -> Raw Expr -> Raw Statement
-mkAugAssign as a b =
+mkAugAssign :: AugAssignOp -> Raw Expr -> Raw Expr -> Raw Statement
+mkAugAssign at a b =
   SimpleStatement
     (Indents [] ())
     (MkSimpleStatement
-       (AugAssign () (a & trailingWhitespace .~ [Space]) (as [Space]) b)
+       (AugAssign () (a & trailingWhitespace .~ [Space]) (MkAugAssign at () [Space]) b)
        []
        Nothing
        Nothing
@@ -1250,55 +1250,55 @@ chainEq t (a:as) =
 infix 0 .=
 
 (.+=) :: Raw Expr -> Raw Expr -> Raw Statement
-(.+=) = mkAugAssign (PlusEq ())
+(.+=) = mkAugAssign PlusEq
 infix 0 .+=
 
 (.-=) :: Raw Expr -> Raw Expr -> Raw Statement
-(.-=) = mkAugAssign (MinusEq ())
+(.-=) = mkAugAssign MinusEq
 infix 0 .-=
 
 (.*=) :: Raw Expr -> Raw Expr -> Raw Statement
-(.*=) = mkAugAssign (StarEq ())
+(.*=) = mkAugAssign StarEq
 infix 0 .*=
 
 (.@=) :: Raw Expr -> Raw Expr -> Raw Statement
-(.@=) = mkAugAssign (AtEq ())
+(.@=) = mkAugAssign AtEq
 infix 0 .@=
 
 (./=) :: Raw Expr -> Raw Expr -> Raw Statement
-(./=) = mkAugAssign (SlashEq ())
+(./=) = mkAugAssign SlashEq
 infix 0 ./=
 
 (.%=) :: Raw Expr -> Raw Expr -> Raw Statement
-(.%=) = mkAugAssign (PercentEq ())
+(.%=) = mkAugAssign PercentEq
 infix 0 .%=
 
 (.&=) :: Raw Expr -> Raw Expr -> Raw Statement
-(.&=) = mkAugAssign (AmpersandEq ())
+(.&=) = mkAugAssign AmpersandEq
 infix 0 .&=
 
 (.|=) :: Raw Expr -> Raw Expr -> Raw Statement
-(.|=) = mkAugAssign (PipeEq ())
+(.|=) = mkAugAssign PipeEq
 infix 0 .|=
 
 (.^=) :: Raw Expr -> Raw Expr -> Raw Statement
-(.^=) = mkAugAssign (CaretEq ())
+(.^=) = mkAugAssign CaretEq
 infix 0 .^=
 
 (.<<=) :: Raw Expr -> Raw Expr -> Raw Statement
-(.<<=) = mkAugAssign (ShiftLeftEq ())
+(.<<=) = mkAugAssign ShiftLeftEq
 infix 0 .<<=
 
 (.>>=) :: Raw Expr -> Raw Expr -> Raw Statement
-(.>>=) = mkAugAssign (ShiftRightEq ())
+(.>>=) = mkAugAssign ShiftRightEq
 infix 0 .>>=
 
 (.**=) :: Raw Expr -> Raw Expr -> Raw Statement
-(.**=) = mkAugAssign (DoubleStarEq ())
+(.**=) = mkAugAssign DoubleStarEq
 infix 0 .**=
 
 (.//=) :: Raw Expr -> Raw Expr -> Raw Statement
-(.//=) = mkAugAssign (DoubleSlashEq ())
+(.//=) = mkAugAssign DoubleSlashEq
 infix 0 .//=
 
 mkFor :: Raw Expr -> [Raw Expr] -> [Raw Line] -> Raw For

--- a/test/Generators/Common.hs
+++ b/test/Generators/Common.hs
@@ -414,6 +414,7 @@ genSizedCommaSep1' ma = Gen.sized $ \n ->
 
 genAugAssign :: MonadGen m => m (AugAssign ())
 genAugAssign =
+  MkAugAssign <$>
   Gen.element
     [ PlusEq
     , MinusEq


### PR DESCRIPTION
This makes AugAssign a single constructor only, which can make it easier
to work with. Similarly, if all we care about is the operation, it's easier
to work only with AugAssignOp.