### PR TITLE
External whitespace

### DIFF
--- a/example/FixMutableDefaultArguments.hs
+++ b/example/FixMutableDefaultArguments.hs
@@ -9,7 +9,7 @@ import Data.Function ((&))
 import Data.Semigroup ((<>))
 
 import Language.Python.Optics
-import Language.Python.Internal.Syntax
+import Language.Python.Internal.Syntax (Expr (..), Whitespace (..), _Exprs)
 import Language.Python.Syntax
 
 fixMutableDefaultArguments :: Raw Statement -> Maybe (Raw Statement)

--- a/example/FixMutableDefaultArguments.hs
+++ b/example/FixMutableDefaultArguments.hs
@@ -9,8 +9,9 @@ import Data.Function ((&))
 import Data.Semigroup ((<>))
 
 import Language.Python.Optics
-import Language.Python.Internal.Syntax (Expr (..), Whitespace (..), _Exprs)
+import Language.Python.Internal.Syntax (Expr (..), _Exprs)
 import Language.Python.Syntax
+import Language.Python.Syntax.Whitespace
 
 fixMutableDefaultArguments :: Raw Statement -> Maybe (Raw Statement)
 fixMutableDefaultArguments input = do

--- a/example/Indentation.hs
+++ b/example/Indentation.hs
@@ -6,7 +6,7 @@ import Control.Lens.Plated (transform)
 import GHC.Natural (Natural)
 
 import Language.Python.Optics
-import Language.Python.Internal.Syntax
+import Language.Python.Internal.Syntax (Statement, Whitespace (Space, Tab))
 
 indentSpaces :: Natural -> Statement '[] a -> Statement '[] a
 indentSpaces n = transform (_Indent .~ replicate (fromIntegral n) Space)

--- a/example/Indentation.hs
+++ b/example/Indentation.hs
@@ -6,7 +6,8 @@ import Control.Lens.Plated (transform)
 import GHC.Natural (Natural)
 
 import Language.Python.Optics
-import Language.Python.Internal.Syntax (Statement, Whitespace (Space, Tab))
+import Language.Python.Internal.Syntax (Statement)
+import Language.Python.Syntax.Whitespace
 
 indentSpaces :: Natural -> Statement '[] a -> Statement '[] a
 indentSpaces n = transform (_Indent .~ replicate (fromIntegral n) Space)

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -9,7 +9,7 @@ import OptimizeTailRecursion
 import Indentation
 
 import Language.Python.Render (showModule)
-import Language.Python.Internal.Syntax
+import Language.Python.Internal.Syntax (_Statements)
 
 import qualified Data.Text.IO as StrictText
 

--- a/example/OptimizeTailRecursion.hs
+++ b/example/OptimizeTailRecursion.hs
@@ -18,8 +18,9 @@ import Data.Semigroup ((<>))
 
 
 import Language.Python.Optics
-import Language.Python.Internal.Syntax (CompoundStatement (..), Expr (..), Statement (..), SimpleStatement (..), SmallStatement (..), Whitespace (..), _Exprs, _Statements, argExpr, paramName)
+import Language.Python.Internal.Syntax (CompoundStatement (..), Expr (..), Statement (..), SimpleStatement (..), SmallStatement (..), _Exprs, _Statements, argExpr, paramName)
 import Language.Python.Syntax
+import Language.Python.Syntax.Whitespace
 
 optimizeTailRecursion :: Raw Statement -> Maybe (Raw Statement)
 optimizeTailRecursion st = do

--- a/example/OptimizeTailRecursion.hs
+++ b/example/OptimizeTailRecursion.hs
@@ -18,7 +18,7 @@ import Data.Semigroup ((<>))
 
 
 import Language.Python.Optics
-import Language.Python.Internal.Syntax
+import Language.Python.Internal.Syntax (CompoundStatement (..), Expr (..), Statement (..), SimpleStatement (..), SmallStatement (..), Whitespace (..), _Exprs, _Statements, argExpr, paramName)
 import Language.Python.Syntax
 
 optimizeTailRecursion :: Raw Statement -> Maybe (Raw Statement)

--- a/example/Programs.hs
+++ b/example/Programs.hs
@@ -6,7 +6,7 @@ import Control.Lens.Getter ((^.))
 import Control.Lens.Iso (from)
 import Data.Function ((&))
 import Data.List.NonEmpty (NonEmpty(..))
-import Language.Python.Internal.Syntax
+import Language.Python.Internal.Syntax (Arg (..), Blank (..), Block (..), CommaSep (..), CommaSep1' (..), CompoundStatement (..), Expr (..), Indents (..), Module (..), Newline (..), Param (..), SimpleStatement (..), SmallStatement (..), Statement (..), Suite (..), Whitespace (..), indentWhitespaces)
 import Language.Python.Syntax
 
 -- |

--- a/example/Programs.hs
+++ b/example/Programs.hs
@@ -6,8 +6,9 @@ import Control.Lens.Getter ((^.))
 import Control.Lens.Iso (from)
 import Data.Function ((&))
 import Data.List.NonEmpty (NonEmpty(..))
-import Language.Python.Internal.Syntax (Arg (..), Blank (..), Block (..), CommaSep (..), CommaSep1' (..), CompoundStatement (..), Expr (..), Indents (..), Module (..), Newline (..), Param (..), SimpleStatement (..), SmallStatement (..), Statement (..), Suite (..), Whitespace (..), indentWhitespaces)
+import Language.Python.Internal.Syntax (Arg (..), Block (..), CommaSep (..), CommaSep1' (..), CompoundStatement (..), Expr (..), Module (..), Param (..), SimpleStatement (..), SmallStatement (..), Statement (..), Suite (..))
 import Language.Python.Syntax
+import Language.Python.Syntax.Whitespace
 
 -- |
 -- @

--- a/hpython.cabal
+++ b/hpython.cabal
@@ -77,13 +77,13 @@ library
                      , Language.Python.Internal.Syntax.Numbers
                      , Language.Python.Internal.Syntax.Statement
                      , Language.Python.Internal.Syntax.Strings
-                     , Language.Python.Internal.Syntax.Whitespace
                      , Language.Python.Optics
                      , Language.Python.Optics.Validated
                      , Language.Python.Parse
                      , Language.Python.Render
                      , Language.Python.Syntax
                      , Language.Python.Syntax.Types
+                     , Language.Python.Syntax.Whitespace
                      , Language.Python.Validate.Scope
                      , Language.Python.Validate.Scope.Error
                      , Language.Python.Validate.Syntax

--- a/src/Language/Python/Internal/Lexer.hs
+++ b/src/Language/Python/Internal/Lexer.hs
@@ -59,6 +59,7 @@ import qualified Text.Megaparsec as Parsec
 
 import Language.Python.Internal.Syntax
 import Language.Python.Internal.Token (PyToken(..), pyTokenAnn)
+import Language.Python.Syntax.Whitespace
 
 data SrcInfo
   = SrcInfo

--- a/src/Language/Python/Internal/Parse.hs
+++ b/src/Language/Python/Internal/Parse.hs
@@ -46,8 +46,8 @@ import Language.Python.Internal.Syntax.Numbers
 import Language.Python.Internal.Syntax.Operator.Binary
 import Language.Python.Internal.Syntax.Operator.Unary
 import Language.Python.Internal.Syntax.Strings
-import Language.Python.Internal.Syntax.Whitespace
 import Language.Python.Internal.Token
+import Language.Python.Syntax.Whitespace
 
 newtype PyTokens = PyTokens { unPyTokens :: [PyToken SrcInfo] }
   deriving (Eq, Ord)

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -46,6 +46,7 @@ import qualified Data.Text.Lazy.Builder as Builder
 import Language.Python.Internal.Syntax
 import Language.Python.Internal.Render.Correction
 import Language.Python.Internal.Token (PyToken(..))
+import Language.Python.Syntax.Whitespace
 
 -- | A 'RenderOutput' is an intermediate form used during rendering
 -- with efficient 'Semigroup' and 'Monoid' instances.

--- a/src/Language/Python/Internal/Render/Correction.hs
+++ b/src/Language/Python/Internal/Render/Correction.hs
@@ -35,7 +35,7 @@ import Language.Python.Internal.Syntax.Numbers
 import Language.Python.Internal.Syntax.Statement
 import Language.Python.Internal.Syntax.Strings
 import Language.Python.Internal.Token
-import Language.Python.Internal.Syntax.Whitespace
+import Language.Python.Syntax.Whitespace
 
 correctSpaces :: (PyToken () -> Text) -> [PyToken ()] -> [PyToken ()]
 correctSpaces f =

--- a/src/Language/Python/Internal/Syntax.hs
+++ b/src/Language/Python/Internal/Syntax.hs
@@ -24,7 +24,6 @@ module Language.Python.Internal.Syntax
   , module Language.Python.Internal.Syntax.Operator.Unary
   , module Language.Python.Internal.Syntax.Statement
   , module Language.Python.Internal.Syntax.Strings
-  , module Language.Python.Internal.Syntax.Whitespace
   )
 where
 
@@ -47,7 +46,6 @@ import Language.Python.Internal.Syntax.Operator.Binary
 import Language.Python.Internal.Syntax.Operator.Unary
 import Language.Python.Internal.Syntax.Statement
 import Language.Python.Internal.Syntax.Strings
-import Language.Python.Internal.Syntax.Whitespace
 
 reservedWords :: [String]
 reservedWords =

--- a/src/Language/Python/Internal/Syntax/AugAssign.hs
+++ b/src/Language/Python/Internal/Syntax/AugAssign.hs
@@ -13,7 +13,7 @@ module Language.Python.Internal.Syntax.AugAssign where
 
 import Control.Lens.Lens (lens)
 
-import Language.Python.Internal.Syntax.Whitespace
+import Language.Python.Syntax.Whitespace
 
 -- | Augmented assignments (PEP 203), such as:
 --

--- a/src/Language/Python/Internal/Syntax/CommaSep.hs
+++ b/src/Language/Python/Internal/Syntax/CommaSep.hs
@@ -23,7 +23,7 @@ import Data.List.NonEmpty (NonEmpty(..))
 import Data.Maybe (fromMaybe)
 import Data.Semigroup (Semigroup(..))
 
-import Language.Python.Internal.Syntax.Whitespace
+import Language.Python.Syntax.Whitespace
 
 data CommaSep a
   = CommaSepNone

--- a/src/Language/Python/Internal/Syntax/Expr.hs
+++ b/src/Language/Python/Internal/Syntax/Expr.hs
@@ -45,7 +45,7 @@ import Language.Python.Internal.Syntax.Numbers
 import Language.Python.Internal.Syntax.Operator.Binary
 import Language.Python.Internal.Syntax.Operator.Unary
 import Language.Python.Internal.Syntax.Strings
-import Language.Python.Internal.Syntax.Whitespace
+import Language.Python.Syntax.Whitespace
 
 {-
 

--- a/src/Language/Python/Internal/Syntax/IR.hs
+++ b/src/Language/Python/Internal/Syntax/IR.hs
@@ -39,7 +39,7 @@ import Language.Python.Internal.Syntax.Numbers
 import Language.Python.Internal.Syntax.Operator.Binary
 import Language.Python.Internal.Syntax.Operator.Unary
 import Language.Python.Internal.Syntax.Strings
-import Language.Python.Internal.Syntax.Whitespace
+import Language.Python.Syntax.Whitespace
 
 import qualified Language.Python.Internal.Syntax as Syntax
 

--- a/src/Language/Python/Internal/Syntax/Ident.hs
+++ b/src/Language/Python/Internal/Syntax/Ident.hs
@@ -18,7 +18,7 @@ import Data.Char (isDigit, isLetter)
 import Data.String (IsString(..))
 
 import Language.Python.Optics.Validated (Validated)
-import Language.Python.Internal.Syntax.Whitespace
+import Language.Python.Syntax.Whitespace
 
 data Ident (v :: [*]) a
   = MkIdent

--- a/src/Language/Python/Internal/Syntax/Import.hs
+++ b/src/Language/Python/Internal/Syntax/Import.hs
@@ -22,7 +22,7 @@ import Data.List.NonEmpty (NonEmpty)
 
 import Language.Python.Internal.Syntax.CommaSep
 import Language.Python.Internal.Syntax.Ident
-import Language.Python.Internal.Syntax.Whitespace
+import Language.Python.Syntax.Whitespace
 
 data ImportAs e v a
   = ImportAs a (e a) (Maybe (NonEmpty Whitespace, Ident v a))

--- a/src/Language/Python/Internal/Syntax/Module.hs
+++ b/src/Language/Python/Internal/Syntax/Module.hs
@@ -12,7 +12,7 @@ Portability : non-portable
 module Language.Python.Internal.Syntax.Module where
 
 import Language.Python.Internal.Syntax.Statement
-import Language.Python.Internal.Syntax.Whitespace
+import Language.Python.Syntax.Whitespace
 
 -- | A Python 'Module', which is stored as a sequence of statements.
 -- A module corresponds to one source file of Python code.

--- a/src/Language/Python/Internal/Syntax/ModuleNames.hs
+++ b/src/Language/Python/Internal/Syntax/ModuleNames.hs
@@ -24,7 +24,7 @@ import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NonEmpty
 
 import Language.Python.Internal.Syntax.Ident
-import Language.Python.Internal.Syntax.Whitespace
+import Language.Python.Syntax.Whitespace
 
 data RelativeModuleName v a
   = RelativeWithName [Dot] (ModuleName v a)

--- a/src/Language/Python/Internal/Syntax/Operator/Binary.hs
+++ b/src/Language/Python/Internal/Syntax/Operator/Binary.hs
@@ -20,7 +20,7 @@ import Control.Lens.TH (makeLenses)
 import Data.Functor (($>))
 import Data.Semigroup ((<>))
 
-import Language.Python.Internal.Syntax.Whitespace
+import Language.Python.Syntax.Whitespace
 
 -- | A Python binary operator, such as @+@, along with its trailing 'Whitespace'
 --

--- a/src/Language/Python/Internal/Syntax/Operator/Unary.hs
+++ b/src/Language/Python/Internal/Syntax/Operator/Unary.hs
@@ -15,7 +15,7 @@ Unary operators
 module Language.Python.Internal.Syntax.Operator.Unary where
 
 import Control.Lens.Lens (lens)
-import Language.Python.Internal.Syntax.Whitespace
+import Language.Python.Syntax.Whitespace
 
 -- | An 'UnOp' is a unary operator in Python, such as @-@ for negation.
 -- An operator is stored with an annotation and its trailing whitespace.

--- a/src/Language/Python/Internal/Syntax/Statement.hs
+++ b/src/Language/Python/Internal/Syntax/Statement.hs
@@ -42,7 +42,7 @@ import Language.Python.Internal.Syntax.Expr
 import Language.Python.Internal.Syntax.Ident
 import Language.Python.Internal.Syntax.Import
 import Language.Python.Internal.Syntax.ModuleNames
-import Language.Python.Internal.Syntax.Whitespace
+import Language.Python.Syntax.Whitespace
 
 -- See note [unsafeCoerce Validation] in Language.Python.Internal.Syntax.Expr
 instance Validated Statement where; unvalidated = to unsafeCoerce

--- a/src/Language/Python/Internal/Syntax/Strings.hs
+++ b/src/Language/Python/Internal/Syntax/Strings.hs
@@ -21,7 +21,7 @@ import Data.Digit.Hexadecimal.MixedCase (HeXDigit(..))
 import Data.Maybe (isJust)
 import Data.Text (Text)
 
-import Language.Python.Internal.Syntax.Whitespace
+import Language.Python.Syntax.Whitespace
 
 data QuoteType
   = SingleQuote

--- a/src/Language/Python/Internal/Token.hs
+++ b/src/Language/Python/Internal/Token.hs
@@ -19,7 +19,7 @@ import Data.Functor.Classes (liftCompare, liftEq)
 import Language.Python.Internal.Syntax.Numbers
 import Language.Python.Internal.Syntax.Strings
 import Language.Python.Internal.Syntax.Comment (Comment(..))
-import Language.Python.Internal.Syntax.Whitespace (Newline(..), Indents)
+import Language.Python.Syntax.Whitespace (Newline(..), Indents)
 
 -- | A 'PyToken' is a single lexical token of Python source. A 'PyToken' has an
 -- optional annotation, which can be '()' when no annotation is desired.

--- a/src/Language/Python/Optics.hs
+++ b/src/Language/Python/Optics.hs
@@ -26,6 +26,7 @@ import Data.Function ((&))
 import Language.Python.Optics.Validated (unvalidated)
 import Language.Python.Internal.Syntax
 import Language.Python.Syntax.Types
+import Language.Python.Syntax.Whitespace
 
 _TupleUnpack :: Prism (TupleItem v a) (TupleItem '[] a) (TupleUnpack v a) (TupleUnpack '[] a)
 _TupleUnpack =

--- a/src/Language/Python/Parse.hs
+++ b/src/Language/Python/Parse.hs
@@ -45,7 +45,8 @@ import Text.Megaparsec.Pos (SourcePos(..))
 import Language.Python.Internal.Lexer
   (SrcInfo(..), initialSrcInfo, withSrcInfo, tokenize, insertTabs)
 import Language.Python.Internal.Token (PyToken)
-import Language.Python.Internal.Syntax (Module, Statement, Expr, Indents(..))
+import Language.Python.Internal.Syntax (Module, Statement, Expr)
+import Language.Python.Syntax.Whitespace (Indents (..))
 
 import qualified Text.Megaparsec.Error as Megaparsec
 import qualified Language.Python.Internal.Lexer as Lexer

--- a/src/Language/Python/Syntax.hs
+++ b/src/Language/Python/Syntax.hs
@@ -360,6 +360,7 @@ import Data.Semigroup ((<>))
 import Language.Python.Optics
 import Language.Python.Internal.Syntax hiding (Fundef, While, Call)
 import Language.Python.Syntax.Types
+import Language.Python.Syntax.Whitespace
 
 type Raw f = f '[] ()
 

--- a/src/Language/Python/Syntax/Types.hs
+++ b/src/Language/Python/Syntax/Types.hs
@@ -17,6 +17,7 @@ import Control.Lens.TH (makeLenses)
 import Data.List.NonEmpty (NonEmpty)
 
 import Language.Python.Internal.Syntax hiding (Fundef, While)
+import Language.Python.Syntax.Whitespace
 
 data Fundef v a
   = MkFundef

--- a/src/Language/Python/Syntax/Whitespace.hs
+++ b/src/Language/Python/Syntax/Whitespace.hs
@@ -4,7 +4,7 @@
 {-# language TemplateHaskell #-}
 
 {-|
-Module      : Language.Python.Internal.Syntax.Whitespace
+Module      : Language.Python.Syntax.Whitespace
 Copyright   : (C) CSIRO 2017-2018
 License     : BSD3
 Maintainer  : Isaac Elliott <isaace71295@gmail.com>
@@ -12,7 +12,7 @@ Stability   : experimental
 Portability : non-portable
 -}
 
-module Language.Python.Internal.Syntax.Whitespace
+module Language.Python.Syntax.Whitespace
   ( Newline(..)
   , Whitespace(..)
   , Blank(..)

--- a/src/Language/Python/Validate/Indentation.hs
+++ b/src/Language/Python/Validate/Indentation.hs
@@ -53,6 +53,7 @@ import qualified Data.List.NonEmpty as NonEmpty
 import Language.Python.Optics
 import Language.Python.Optics.Validated (unvalidated)
 import Language.Python.Internal.Syntax
+import Language.Python.Syntax.Whitespace
 import Language.Python.Validate.Indentation.Error
 
 data Indentation

--- a/src/Language/Python/Validate/Indentation/Error.hs
+++ b/src/Language/Python/Validate/Indentation/Error.hs
@@ -16,7 +16,7 @@ module Language.Python.Validate.Indentation.Error where
 import Control.Lens.Type
 import Control.Lens.Prism
 
-import Language.Python.Internal.Syntax
+import Language.Python.Syntax.Whitespace
 
 
 data IndentationError (v :: [*]) a

--- a/src/Language/Python/Validate/Syntax.hs
+++ b/src/Language/Python/Validate/Syntax.hs
@@ -86,6 +86,7 @@ import qualified Data.List.NonEmpty as NonEmpty
 import Language.Python.Optics
 import Language.Python.Optics.Validated (unvalidated)
 import Language.Python.Internal.Syntax
+import Language.Python.Syntax.Whitespace
 import Language.Python.Validate.Indentation
 import Language.Python.Validate.Syntax.Error
 

--- a/src/Language/Python/Validate/Syntax/Error.hs
+++ b/src/Language/Python/Validate/Syntax/Error.hs
@@ -17,6 +17,7 @@ module Language.Python.Validate.Syntax.Error where
 import Control.Lens.Type
 import Control.Lens.Prism
 import Language.Python.Internal.Syntax
+import Language.Python.Syntax.Whitespace
 
 data SyntaxError (v :: [*]) a
   = PositionalAfterKeywordArg a (Expr v a)

--- a/test/Generators/Common.hs
+++ b/test/Generators/Common.hs
@@ -17,6 +17,7 @@ import Data.These (These(..))
 import qualified Data.List.NonEmpty as NonEmpty
 
 import Language.Python.Internal.Syntax
+import Language.Python.Syntax.Whitespace
 import Generators.Sized
 
 genSimpleStatement

--- a/test/Generators/Correct.hs
+++ b/test/Generators/Correct.hs
@@ -31,6 +31,7 @@ import GHC.Stack
 import Language.Python.Syntax.Types (spType)
 import Language.Python.Optics
 import Language.Python.Internal.Syntax
+import Language.Python.Syntax.Whitespace
 
 import Generators.Common
 import Generators.Sized

--- a/test/Generators/General.hs
+++ b/test/Generators/General.hs
@@ -10,6 +10,7 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import Language.Python.Internal.Syntax
+import Language.Python.Syntax.Whitespace
 
 import Generators.Common
 import Generators.Sized

--- a/test/Optics.hs
+++ b/test/Optics.hs
@@ -11,7 +11,8 @@ import qualified Data.Text.IO as Text
 
 import Language.Python.Parse (parseModule)
 import Language.Python.Render (showModule)
-import Language.Python.Internal.Syntax (Whitespace(..), _Statements)
+import Language.Python.Internal.Syntax (_Statements)
+import Language.Python.Syntax.Whitespace (Whitespace (..))
 import Language.Python.Optics (_Indent)
 
 opticsTests :: Group

--- a/test/Scope.hs
+++ b/test/Scope.hs
@@ -14,6 +14,7 @@ import Language.Python.Validate.Indentation
 import Language.Python.Validate.Scope
 import Language.Python.Internal.Syntax
 import Language.Python.Syntax
+import Language.Python.Syntax.Whitespace
 
 scopeTests :: Group
 scopeTests = $$discover

--- a/test/Syntax.hs
+++ b/test/Syntax.hs
@@ -11,8 +11,8 @@ import Language.Python.Render (showStatement)
 import Language.Python.Internal.Syntax.CommaSep
 import Language.Python.Internal.Syntax.Expr
 import Language.Python.Internal.Syntax.Statement
-import Language.Python.Internal.Syntax.Whitespace
 import Language.Python.Parse (parseStatement)
+import Language.Python.Syntax.Whitespace
 
 import Helpers
   (shouldBeFailure, shouldBeSuccess, syntaxValidateExpr)


### PR DESCRIPTION
This is a small but ubiquitous module, so I thought it would be a good example of what I'm talking about. This PR makes it external rather than internal.

My current measure of which things should be external is: no internal code should be used in examples. No internal code should be used in my reindent tool.

Discussion points:
* Should I keep L.P.Internal.Syntax.Whitespace and simply reexport it from L.P.Syntax.Whitespace (rather than deleting the former)?
* Should L.P.Syntax reexport L.P.Syntax.Whitespace?