### PR TITLE
Export statements

### DIFF
--- a/example/FixMutableDefaultArguments.hs
+++ b/example/FixMutableDefaultArguments.hs
@@ -9,9 +9,9 @@ import Data.Function ((&))
 import Data.Semigroup ((<>))
 
 import Language.Python.Optics
-import Language.Python.Internal.Syntax (Expr (..), _Exprs)
 import Language.Python.DSL
-import Language.Python.Syntax.Whitespace
+import Language.Python.Syntax.Expr (Expr (..), _Exprs)
+import Language.Python.Syntax.Whitespace (Whitespace (Space))
 
 fixMutableDefaultArguments :: Raw Statement -> Maybe (Raw Statement)
 fixMutableDefaultArguments input = do

--- a/example/Indentation.hs
+++ b/example/Indentation.hs
@@ -6,8 +6,8 @@ import Control.Lens.Plated (transform)
 import GHC.Natural (Natural)
 
 import Language.Python.Optics
-import Language.Python.Internal.Syntax (Statement)
-import Language.Python.Syntax.Whitespace
+import Language.Python.Syntax.Statement (Statement)
+import Language.Python.Syntax.Whitespace (Whitespace (Space, Tab))
 
 indentSpaces :: Natural -> Statement '[] a -> Statement '[] a
 indentSpaces n = transform (_Indent .~ replicate (fromIntegral n) Space)

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -9,7 +9,7 @@ import OptimizeTailRecursion
 import Indentation
 
 import Language.Python.Render (showModule)
-import Language.Python.Internal.Syntax (_Statements)
+import Language.Python.Syntax.Statement (_Statements)
 
 import qualified Data.Text.IO as StrictText
 

--- a/example/OptimizeTailRecursion.hs
+++ b/example/OptimizeTailRecursion.hs
@@ -18,9 +18,10 @@ import Data.Semigroup ((<>))
 
 
 import Language.Python.Optics
-import Language.Python.Internal.Syntax (CompoundStatement (..), Expr (..), Statement (..), SimpleStatement (..), SmallStatement (..), _Exprs, _Statements, argExpr, paramName)
 import Language.Python.DSL
-import Language.Python.Syntax.Whitespace
+import Language.Python.Syntax.Expr (Expr (..), _Exprs, argExpr, paramName)
+import Language.Python.Syntax.Statement (CompoundStatement (..), Statement (..), SimpleStatement (..), SmallStatement (..), _Statements)
+import Language.Python.Syntax.Whitespace (Whitespace (Space))
 
 optimizeTailRecursion :: Raw Statement -> Maybe (Raw Statement)
 optimizeTailRecursion st = do

--- a/example/Programs.hs
+++ b/example/Programs.hs
@@ -6,9 +6,13 @@ import Control.Lens.Getter ((^.))
 import Control.Lens.Iso (from)
 import Data.Function ((&))
 import Data.List.NonEmpty (NonEmpty(..))
-import Language.Python.Internal.Syntax (Arg (..), Block (..), CommaSep (..), CommaSep1' (..), CompoundStatement (..), Expr (..), Module (..), Param (..), SimpleStatement (..), SmallStatement (..), Statement (..), Suite (..))
+
 import Language.Python.DSL
-import Language.Python.Syntax.Whitespace
+import Language.Python.Internal.Syntax.Module (Module (..))
+import Language.Python.Internal.Syntax.CommaSep (CommaSep (..), CommaSep1' (..))
+import Language.Python.Syntax.Expr (Arg (..), Expr (..), Param (..))
+import Language.Python.Syntax.Statement (Block (..), CompoundStatement (..), SimpleStatement (..), SmallStatement (..), Statement (..), Suite (..))
+import Language.Python.Syntax.Whitespace (Blank (..), Indents (..), Newline (..), Whitespace (..), indentWhitespaces)
 
 -- |
 -- @

--- a/hpython-test/src/Generators/Common.hs
+++ b/hpython-test/src/Generators/Common.hs
@@ -17,6 +17,7 @@ import Data.These (These(..))
 import qualified Data.List.NonEmpty as NonEmpty
 
 import Language.Python.Internal.Syntax
+import Language.Python.Syntax.Statement
 import Language.Python.Syntax.Whitespace
 import Generators.Sized
 

--- a/hpython-test/src/Generators/Correct.hs
+++ b/hpython-test/src/Generators/Correct.hs
@@ -31,6 +31,7 @@ import GHC.Stack
 import Language.Python.Syntax.Types (spType)
 import Language.Python.Optics
 import Language.Python.Internal.Syntax
+import Language.Python.Syntax.Statement
 import Language.Python.Syntax.Whitespace
 
 import Generators.Common

--- a/hpython-test/src/Generators/General.hs
+++ b/hpython-test/src/Generators/General.hs
@@ -10,6 +10,7 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import Language.Python.Internal.Syntax
+import Language.Python.Syntax.Statement
 import Language.Python.Syntax.Whitespace
 
 import Generators.Common

--- a/hpython-test/test/Main.hs
+++ b/hpython-test/test/Main.hs
@@ -20,6 +20,7 @@ import Language.Python.Internal.Syntax
 import Language.Python.Optics.Validated (unvalidated)
 import Language.Python.Parse (parseStatement, parseExpr, parseExprList)
 import Language.Python.Render
+import Language.Python.Syntax.Statement
 import Language.Python.Validate
 
 import Hedgehog

--- a/hpython.cabal
+++ b/hpython.cabal
@@ -84,7 +84,6 @@ library
                      , Language.Python.Internal.Syntax.Operator.Binary
                      , Language.Python.Internal.Syntax.Operator.Unary
                      , Language.Python.Internal.Syntax.Numbers
-                     , Language.Python.Internal.Syntax.Statement
                      , Language.Python.Internal.Syntax.Strings
                      , Language.Python.Optics
                      , Language.Python.Optics.Validated
@@ -92,6 +91,7 @@ library
                      , Language.Python.Render
                      , Language.Python.Syntax
                      , Language.Python.Syntax.Expr
+                     , Language.Python.Syntax.Statement
                      , Language.Python.Syntax.Types
                      , Language.Python.Syntax.Whitespace
                      , Language.Python.Validate

--- a/src/Language/Python/DSL.hs
+++ b/src/Language/Python/DSL.hs
@@ -358,7 +358,14 @@ import Data.Maybe (fromMaybe)
 import Data.Semigroup ((<>))
 
 import Language.Python.Optics
-import Language.Python.Internal.Syntax hiding (Fundef, While, Call)
+import Language.Python.Internal.Syntax.AugAssign
+import Language.Python.Internal.Syntax.CommaSep
+import Language.Python.Internal.Syntax.Ident
+import Language.Python.Internal.Syntax.Strings
+import Language.Python.Internal.Syntax.Operator.Binary
+import Language.Python.Internal.Syntax.Operator.Unary
+import Language.Python.Syntax.Expr
+import Language.Python.Syntax.Statement
 import Language.Python.Syntax.Types
 import Language.Python.Syntax.Whitespace
 

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -50,7 +50,19 @@ import qualified Data.Text as Text
 import qualified Data.Text.Lazy as Lazy
 import qualified Data.Text.Lazy.Builder as Builder
 
-import Language.Python.Internal.Syntax
+import Language.Python.Syntax.Expr
+import Language.Python.Syntax.Statement
+import Language.Python.Internal.Syntax.AugAssign
+import Language.Python.Internal.Syntax.Comment
+import Language.Python.Internal.Syntax.CommaSep
+import Language.Python.Internal.Syntax.Ident
+import Language.Python.Internal.Syntax.Import
+import Language.Python.Internal.Syntax.Module
+import Language.Python.Internal.Syntax.ModuleNames
+import Language.Python.Internal.Syntax.Numbers
+import Language.Python.Internal.Syntax.Operator.Binary
+import Language.Python.Internal.Syntax.Operator.Unary
+import Language.Python.Internal.Syntax.Strings
 import Language.Python.Internal.Render.Correction
 import Language.Python.Internal.Token (PyToken(..))
 import Language.Python.Syntax.Whitespace

--- a/src/Language/Python/Internal/Syntax.hs
+++ b/src/Language/Python/Internal/Syntax.hs
@@ -22,7 +22,6 @@ module Language.Python.Internal.Syntax
   , module Language.Python.Internal.Syntax.Numbers
   , module Language.Python.Internal.Syntax.Operator.Binary
   , module Language.Python.Internal.Syntax.Operator.Unary
-  , module Language.Python.Internal.Syntax.Statement
   , module Language.Python.Internal.Syntax.Strings
   )
 where
@@ -44,7 +43,6 @@ import Language.Python.Internal.Syntax.ModuleNames
 import Language.Python.Internal.Syntax.Numbers
 import Language.Python.Internal.Syntax.Operator.Binary
 import Language.Python.Internal.Syntax.Operator.Unary
-import Language.Python.Internal.Syntax.Statement
 import Language.Python.Internal.Syntax.Strings
 
 reservedWords :: [String]

--- a/src/Language/Python/Internal/Syntax/IR.hs
+++ b/src/Language/Python/Internal/Syntax/IR.hs
@@ -41,7 +41,9 @@ import Language.Python.Internal.Syntax.Operator.Unary
 import Language.Python.Internal.Syntax.Strings
 import Language.Python.Syntax.Whitespace
 
-import qualified Language.Python.Internal.Syntax as Syntax
+import qualified Language.Python.Internal.Syntax.Module as Syntax
+import qualified Language.Python.Syntax.Expr as Syntax
+import qualified Language.Python.Syntax.Statement as Syntax
 
 data IRError a = InvalidUnpacking a
   deriving (Eq, Show)

--- a/src/Language/Python/Internal/Syntax/Module.hs
+++ b/src/Language/Python/Internal/Syntax/Module.hs
@@ -11,7 +11,7 @@ Portability : non-portable
 
 module Language.Python.Internal.Syntax.Module where
 
-import Language.Python.Internal.Syntax.Statement
+import Language.Python.Syntax.Statement
 import Language.Python.Syntax.Whitespace
 
 -- | A Python 'Module', which is stored as a sequence of statements.

--- a/src/Language/Python/Optics.hs
+++ b/src/Language/Python/Optics.hs
@@ -24,7 +24,10 @@ import Data.Coerce (coerce)
 import Data.Function ((&))
 
 import Language.Python.Optics.Validated (unvalidated)
-import Language.Python.Internal.Syntax
+import Language.Python.Syntax.Expr (Expr (..), TupleItem (TupleUnpack), ListItem (ListUnpack), Param (..), _Exprs)
+import Language.Python.Internal.Syntax.Module
+import Language.Python.Internal.Syntax.Ident
+import Language.Python.Syntax.Statement (Block (..), CompoundStatement (..), Decorator (..), ExceptAs (..), SimpleStatement (..), Statement (..), Suite (..), _Statements)
 import Language.Python.Syntax.Types
 import Language.Python.Syntax.Whitespace
 

--- a/src/Language/Python/Parse.hs
+++ b/src/Language/Python/Parse.hs
@@ -45,7 +45,9 @@ import Text.Megaparsec.Pos (SourcePos(..))
 import Language.Python.Internal.Lexer
   (SrcInfo(..), initialSrcInfo, withSrcInfo, tokenize, insertTabs)
 import Language.Python.Internal.Token (PyToken)
-import Language.Python.Internal.Syntax (Module, Statement, Expr)
+import Language.Python.Internal.Syntax (Module)
+import Language.Python.Syntax.Expr (Expr)
+import Language.Python.Syntax.Statement (Statement)
 import Language.Python.Syntax.Whitespace (Indents (..))
 
 import qualified Text.Megaparsec.Error as Megaparsec

--- a/src/Language/Python/Syntax.hs
+++ b/src/Language/Python/Syntax.hs
@@ -9,12 +9,13 @@ Portability : non-portable
 
 module Language.Python.Syntax
   ( module Language.Python.Syntax.Expr
+  , module Language.Python.Syntax.Statement
   , module Language.Python.Syntax.Types
   , module Language.Python.Syntax.Whitespace
   )
 where
 
 import Language.Python.Syntax.Expr
+import Language.Python.Syntax.Statement
 import Language.Python.Syntax.Types
 import Language.Python.Syntax.Whitespace
-

--- a/src/Language/Python/Syntax/Statement.hs
+++ b/src/Language/Python/Syntax/Statement.hs
@@ -7,7 +7,7 @@
 {-# language UndecidableInstances #-}
 
 {-|
-Module      : Language.Python.Internal.Syntax.Statement
+Module      : Language.Python.Syntax.Statement
 Copyright   : (C) CSIRO 2017-2018
 License     : BSD3
 Maintainer  : Isaac Elliott <isaace71295@gmail.com>
@@ -15,7 +15,18 @@ Stability   : experimental
 Portability : non-portable
 -}
 
-module Language.Python.Internal.Syntax.Statement where
+module Language.Python.Syntax.Statement
+  ( Statement (..), HasStatements (..)
+  , SimpleStatement (..)
+  , CompoundStatement (..)
+  , SmallStatement (..)
+  , Block (..), HasBlocks (..), blockBlankLines, blockHead, blockTail
+  , Suite (..)
+  , WithItem (..)
+  , Decorator (..)
+  , ExceptAs (..), exceptAsAnn, exceptAsExpr, exceptAsName
+  )
+where
 
 import Control.Lens.Cons (_last)
 import Control.Lens.Fold (foldMapOf, folded)

--- a/src/Language/Python/Syntax/Types.hs
+++ b/src/Language/Python/Syntax/Types.hs
@@ -16,7 +16,10 @@ module Language.Python.Syntax.Types where
 import Control.Lens.TH (makeLenses)
 import Data.List.NonEmpty (NonEmpty)
 
-import Language.Python.Internal.Syntax hiding (Fundef, While)
+import Language.Python.Internal.Syntax.CommaSep (CommaSep, CommaSep1, CommaSep1')
+import Language.Python.Internal.Syntax.Ident (Ident)
+import Language.Python.Syntax.Expr (Arg, Expr, ListItem, Param, TupleItem)
+import Language.Python.Syntax.Statement (Decorator, ExceptAs, Suite, WithItem)
 import Language.Python.Syntax.Whitespace
 
 data Fundef v a

--- a/src/Language/Python/Validate/Indentation.hs
+++ b/src/Language/Python/Validate/Indentation.hs
@@ -52,7 +52,10 @@ import qualified Data.List.NonEmpty as NonEmpty
 
 import Language.Python.Optics
 import Language.Python.Optics.Validated (unvalidated)
-import Language.Python.Internal.Syntax
+import Language.Python.Internal.Syntax.CommaSep
+import Language.Python.Internal.Syntax.Module
+import Language.Python.Syntax.Expr
+import Language.Python.Syntax.Statement
 import Language.Python.Syntax.Whitespace
 import Language.Python.Validate.Indentation.Error
 

--- a/src/Language/Python/Validate/Scope.hs
+++ b/src/Language/Python/Validate/Scope.hs
@@ -81,7 +81,10 @@ import qualified Data.Map.Strict as Map
 
 import Language.Python.Optics
 import Language.Python.Optics.Validated (unvalidated)
-import Language.Python.Internal.Syntax
+import Language.Python.Syntax.Statement
+import Language.Python.Syntax.Expr
+import Language.Python.Internal.Syntax.Ident
+import Language.Python.Internal.Syntax.Module
 import Language.Python.Validate.Scope.Error
 
 data Scope

--- a/src/Language/Python/Validate/Syntax.hs
+++ b/src/Language/Python/Validate/Syntax.hs
@@ -85,7 +85,14 @@ import qualified Data.List.NonEmpty as NonEmpty
 
 import Language.Python.Optics
 import Language.Python.Optics.Validated (unvalidated)
-import Language.Python.Internal.Syntax
+import Language.Python.Internal.Syntax (reservedWords)
+import Language.Python.Internal.Syntax.CommaSep
+import Language.Python.Internal.Syntax.Ident
+import Language.Python.Internal.Syntax.Import
+import Language.Python.Internal.Syntax.Module
+import Language.Python.Internal.Syntax.Strings
+import Language.Python.Syntax.Expr
+import Language.Python.Syntax.Statement
 import Language.Python.Syntax.Whitespace
 import Language.Python.Validate.Indentation
 import Language.Python.Validate.Syntax.Error

--- a/src/Language/Python/Validate/Syntax/Error.hs
+++ b/src/Language/Python/Validate/Syntax/Error.hs
@@ -16,8 +16,10 @@ module Language.Python.Validate.Syntax.Error where
 -- import Control.Lens.TH
 import Control.Lens.Type
 import Control.Lens.Prism
-import Language.Python.Internal.Syntax
-import Language.Python.Syntax.Whitespace
+import Language.Python.Syntax.Expr (Expr)
+import Language.Python.Internal.Syntax.Ident (Ident)
+import Language.Python.Syntax.Statement (Statement)
+import Language.Python.Syntax.Whitespace (Newline, Whitespace)
 
 data SyntaxError (v :: [*]) a
   = PositionalAfterKeywordArg a (Expr v a)

--- a/test/Helpers.hs
+++ b/test/Helpers.hs
@@ -16,8 +16,10 @@ import Language.Python.Internal.Lexer
   )
 import Language.Python.Internal.Token (PyToken)
 import Language.Python.Internal.Parse (Parser, runParser)
-import Language.Python.Internal.Syntax (Module, Statement, Expr)
+import Language.Python.Internal.Syntax (Module)
 import Language.Python.Parse (ParseError, ErrorItem(..), _ParseError)
+import Language.Python.Syntax.Statement (Statement)
+import Language.Python.Syntax.Expr (Expr)
 import Language.Python.Validate
 
 doTokenize :: Monad m => Text -> PropertyT m [PyToken SrcInfo]

--- a/test/Optics.hs
+++ b/test/Optics.hs
@@ -11,7 +11,7 @@ import qualified Data.Text.IO as Text
 
 import Language.Python.Parse (parseModule)
 import Language.Python.Render (showModule)
-import Language.Python.Internal.Syntax (_Statements)
+import Language.Python.Syntax.Statement (_Statements)
 import Language.Python.Syntax.Whitespace (Whitespace (..))
 import Language.Python.Optics (_Indent)
 

--- a/test/Syntax.hs
+++ b/test/Syntax.hs
@@ -9,10 +9,10 @@ import Control.Lens.Getter ((^.))
 import Control.Monad (void)
 import Language.Python.Render (showStatement, showExpr)
 import Language.Python.Internal.Syntax.CommaSep
-import Language.Python.Internal.Syntax.Statement
 import Language.Python.Internal.Syntax.Strings
 import Language.Python.Parse (parseModule, parseStatement, parseExpr)
 import Language.Python.Syntax.Expr
+import Language.Python.Syntax.Statement
 import Language.Python.Syntax.Whitespace
 
 import Helpers


### PR DESCRIPTION
Since there was nothing I wanted to "hide" in Internal, I just moved the module rather than creating a second one for the external definitions. This avoids common mistakes (like adding a definition to the internal module but forgetting to export it from the external one).
Since this is also the case for `Expr`, I'd like to go back and do this for that one.

* Do you agree with this approach?
* Do you agree with applying this to Expr as well?

I've also started splitting the import statements inside hpython into more granular imports (rather than importing `Language.Python.Syntax.Internal`, importing two or three modules directly that that module reexports). This is giving me more visibility which I'm appreciating.

* How do you fell about the import splitting so far?
* If you're cool with it, are you happy for me to continue as I go?