### PR TITLE
Module names

### DIFF
--- a/hpython-test/src/Generators/Correct.hs
+++ b/hpython-test/src/Generators/Correct.hs
@@ -157,7 +157,7 @@ genModuleName =
   [ ModuleNameOne () <$> genIdent ]
   [ ModuleNameMany () <$>
     genIdent <*>
-    genWhitespaces <*>
+    genDot <*>
     genModuleName
   ]
 

--- a/hpython-test/src/Generators/General.hs
+++ b/hpython-test/src/Generators/General.hs
@@ -71,7 +71,7 @@ genModuleName =
   [ ModuleNameOne () <$> genIdent ]
   [ ModuleNameMany () <$>
     genIdent <*>
-    genWhitespaces <*>
+    genDot <*>
     genModuleName
   ]
 

--- a/src/Data/Type/Set.hs
+++ b/src/Data/Type/Set.hs
@@ -12,7 +12,7 @@ Portability : non-portable
 This module defines some helpful set-like functions for working with type-level lists.
 -}
 
-module Data.Type.Set where
+module Data.Type.Set (Nub, Member) where
 
 -- | Remove adjacent equal elements from a type-level list
 type family Nub t where

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -1000,10 +1000,9 @@ renderExpr (Await _ ws expr) = do
 
 renderModuleName :: ModuleName v a -> RenderOutput ()
 renderModuleName (ModuleNameOne _ s) = renderIdent s
-renderModuleName (ModuleNameMany _ n ws2 rest) = do
+renderModuleName (ModuleNameMany _ n dot rest) = do
   renderIdent n
-  singleton $ TkDot ()
-  traverse_ renderWhitespace ws2
+  renderDot dot
   renderModuleName rest
 
 renderDot :: Dot -> RenderOutput ()

--- a/src/Language/Python/Optics/Validated.hs
+++ b/src/Language/Python/Optics/Validated.hs
@@ -9,7 +9,9 @@ Stability   : experimental
 Portability : non-portable
 -}
 
-module Language.Python.Optics.Validated where
+module Language.Python.Optics.Validated (
+  Validated (unvalidated)
+) where
 
 import Control.Lens.Getter (Getter, to)
 import Data.Coerce (Coercible, coerce)


### PR DESCRIPTION
The next step is to make this guy external.

Also, I really liked replacing `[Whitespace]` with `Dot`. I find it much easier to deal with than seeing `[Whitespace]` and having to figure out which symbol implicitly precedes it.
In that vein, what do you think about a `Comma` type to be used in `CommaSep`?