### PR TITLE
Changes that make re-indentation easier

### DIFF
--- a/hpython-test/test/Main.hs
+++ b/hpython-test/test/Main.hs
@@ -17,7 +17,8 @@ import System.Process
 
 import Language.Python.Internal.Syntax
 import Language.Python.Optics.Validated (unvalidated)
-import Language.Python.Parse (parseStatement, parseExpr, parseExprList)
+import Language.Python.Parse (SrcInfo, parseStatement, parseExpr, parseExprList)
+import Language.Python.Parse.Error (ParseError)
 import Language.Python.Render
 import Language.Python.Syntax.Expr
 import Language.Python.Syntax.Module
@@ -142,7 +143,7 @@ string_correct path =
 
     let ex' = showExpr ex
     py <-
-      validation (\e -> annotateShow e *> failure) pure $
+      validation (\e -> annotateShow (e :: NonEmpty (ParseError SrcInfo)) *> failure) pure $
       parseExpr "test" ex'
 
     goodExpr path $ () <$ py
@@ -192,7 +193,7 @@ expr_printparseprint_print =
           Failure errs' -> annotateShow errs' *> failure
           Success res' -> do
             _ <-
-              validation (\e -> annotateShow e *> failure) pure $
+              validation (\e -> annotateShow (e :: NonEmpty (ParseError SrcInfo)) *> failure) pure $
               parseExprList "test" (showExpr res')
             showExpr (res' ^. unvalidated) === showExpr (res $> ())
 
@@ -208,7 +209,7 @@ statement_printparseprint_print =
           Failure errs' -> annotateShow errs' *> failure
           Success res' -> do
             py <-
-              validation (\e -> annotateShow e *> failure) pure $
+              validation (\e -> annotateShow (e :: NonEmpty (ParseError SrcInfo)) *> failure) pure $
               parseStatement "test" (showStatement res')
             annotateShow py
             annotateShow $ showStatement (() <$ py)

--- a/hpython.cabal
+++ b/hpython.cabal
@@ -85,6 +85,7 @@ library
                      , Language.Python.Optics
                      , Language.Python.Optics.Validated
                      , Language.Python.Parse
+                     , Language.Python.Parse.Error
                      , Language.Python.Render
                      , Language.Python.Syntax
                      , Language.Python.Syntax.CommaSep

--- a/src/Language/Python/DSL.hs
+++ b/src/Language/Python/DSL.hs
@@ -12,6 +12,7 @@ passing @['line_' 'pass_']@
 
 
 {-# language DataKinds #-}
+{-# language FlexibleContexts #-}
 {-# language MultiParamTypeClasses, FunctionalDependencies, FlexibleInstances #-}
 {-# language LambdaCase #-}
 {-# language RankNTypes #-}
@@ -612,7 +613,7 @@ instance HasDecorators Fundef where
   getDecorators code = code ^.. fdDecorators.folded._Exprs
 
 mkSetBody
-  :: HasIndents s
+  :: HasIndents (Raw s) ()
   => Setter' (Raw s) (Raw Suite)
   -> (Raw s -> Indents ())
   -> [Whitespace]
@@ -628,7 +629,7 @@ mkSetBody bodyField indentsField ws new code =
       (SuiteMany () [] Nothing LF $ toBlock new)
 
 mkGetBody
-  :: HasIndents s
+  :: HasIndents (Raw s) ()
   => String
   -> (Raw s -> Raw Suite)
   -> (Raw s -> Indents ())

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -855,6 +855,7 @@ renderExpr (Subscript _ a b c d) = do
      Not{} -> parens $ renderExpr a
      Ternary{} -> parens $ renderExpr a
      Lambda{} -> parens $ renderExpr a
+     Await{} -> parens $ renderExpr a
      _ -> parensTupleGenerator a)
   brackets $ do
     traverse_ renderWhitespace b

--- a/src/Language/Python/Internal/Syntax/IR.hs
+++ b/src/Language/Python/Internal/Syntax/IR.hs
@@ -1,5 +1,6 @@
 {-# language DataKinds #-}
 {-# language DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
+{-# language FunctionalDependencies, MultiParamTypeClasses #-}
 {-# language LambdaCase #-}
 {-# language TemplateHaskell #-}
 
@@ -17,6 +18,8 @@ module Language.Python.Internal.Syntax.IR where
 import Control.Lens.Fold (foldMapOf, folded)
 import Control.Lens.Getter ((^.))
 import Control.Lens.Lens (Lens', lens)
+import Control.Lens.Prism (Prism')
+import Control.Lens.Review ((#))
 import Control.Lens.Setter ((.~), over, mapped)
 import Control.Lens.TH (makeLenses)
 import Control.Lens.Traversal (traverseOf)
@@ -45,8 +48,14 @@ import qualified Language.Python.Syntax.Module as Syntax
 import qualified Language.Python.Syntax.Expr as Syntax
 import qualified Language.Python.Syntax.Statement as Syntax
 
+class AsIRError s a | s -> a where
+  _InvalidUnpacking :: Prism' s a
+
 data IRError a = InvalidUnpacking a
   deriving (Eq, Show)
+
+fromIRError :: AsIRError s a => IRError a -> s
+fromIRError (InvalidUnpacking a) = _InvalidUnpacking # a
 
 data SimpleStatement a
   = MkSimpleStatement
@@ -627,10 +636,13 @@ data FromIRContext
 
 makeLenses ''FromIRContext
 
-fromIR_expr :: Expr a -> Validation (NonEmpty (IRError a)) (Syntax.Expr '[] a)
+fromIR_expr
+  :: AsIRError e a
+  => Expr a
+  -> Validation (NonEmpty e) (Syntax.Expr '[] a)
 fromIR_expr ex =
   case ex of
-    StarExpr{} -> Failure (pure (InvalidUnpacking $ ex ^. exprAnn))
+    StarExpr{} -> Failure $ pure (_InvalidUnpacking # (ex ^. exprAnn))
     Unit a b c -> pure $ Syntax.Unit a b c
     Lambda a b c d e ->
       (\c' -> Syntax.Lambda a b c' d) <$>
@@ -697,7 +709,10 @@ fromIR_expr ex =
     Generator a b -> Syntax.Generator a <$> fromIR_comprehension fromIR_expr b
     Await a b c -> Syntax.Await a b <$> fromIR_expr c
 
-fromIR_suite :: Suite a -> Validation (NonEmpty (IRError a)) (Syntax.Suite '[] a)
+fromIR_suite
+  :: AsIRError e a
+  => Suite a
+  -> Validation (NonEmpty e) (Syntax.Suite '[] a)
 fromIR_suite s =
   case s of
     SuiteOne a b c ->
@@ -705,7 +720,10 @@ fromIR_suite s =
     SuiteMany a b c d e ->
       Syntax.SuiteMany a b c d <$> fromIR_block e
 
-fromIR_param :: Param a -> Validation (NonEmpty (IRError a)) (Syntax.Param '[] a)
+fromIR_param
+  :: AsIRError e a
+  => Param a
+  -> Validation (NonEmpty e) (Syntax.Param '[] a)
 fromIR_param p =
   case p of
     PositionalParam a b c ->
@@ -720,7 +738,10 @@ fromIR_param p =
     DoubleStarParam a b c d ->
       Syntax.DoubleStarParam a b c <$> traverseOf (traverse._2) fromIR_expr d
 
-fromIR_arg :: Arg a -> Validation (NonEmpty (IRError a)) (Syntax.Arg '[] a)
+fromIR_arg
+  :: AsIRError e a
+  => Arg a
+  -> Validation (NonEmpty e) (Syntax.Arg '[] a)
 fromIR_arg a =
   case a of
     PositionalArg a b -> Syntax.PositionalArg a <$> fromIR_expr b
@@ -729,34 +750,45 @@ fromIR_arg a =
     DoubleStarArg a b c -> Syntax.DoubleStarArg a b <$> fromIR_expr c
 
 fromIR_decorator
-  :: Decorator a
-  -> Validation (NonEmpty (IRError a)) (Syntax.Decorator '[] a)
+  :: AsIRError e a
+  => Decorator a
+  -> Validation (NonEmpty e) (Syntax.Decorator '[] a)
 fromIR_decorator (Decorator a b c d e f g) =
   (\d' -> Syntax.Decorator a b c d' e f g) <$>
   fromIR_expr d
 
-fromIR_exceptAs :: ExceptAs a -> Validation (NonEmpty (IRError a)) (Syntax.ExceptAs '[] a)
+fromIR_exceptAs
+  :: AsIRError e a
+  => ExceptAs a
+  -> Validation (NonEmpty e) (Syntax.ExceptAs '[] a)
 fromIR_exceptAs (ExceptAs a b c) =
   (\b' -> Syntax.ExceptAs a b' c) <$>
   fromIR_expr b
 
-fromIR_withItem :: WithItem a -> Validation (NonEmpty (IRError a)) (Syntax.WithItem '[] a)
+fromIR_withItem
+  :: AsIRError e a
+  => WithItem a
+  -> Validation (NonEmpty e) (Syntax.WithItem '[] a)
 fromIR_withItem (WithItem a b c) =
   Syntax.WithItem a <$>
   fromIR_expr b <*>
   traverseOf (traverse._2) fromIR_expr c
 
 fromIR_comprehension
-  :: (e a -> Validation (NonEmpty (IRError a)) (e' '[] a))
-  -> Comprehension e a
-  -> Validation (NonEmpty (IRError a)) (Syntax.Comprehension e' '[] a)
+  :: AsIRError e a
+  => (ex a -> Validation (NonEmpty e) (ex' '[] a))
+  -> Comprehension ex a
+  -> Validation (NonEmpty e) (Syntax.Comprehension ex' '[] a)
 fromIR_comprehension f (Comprehension a b c d) =
   Syntax.Comprehension a <$>
   f b <*>
   fromIR_compFor c <*>
   traverse (bitraverse fromIR_compFor fromIR_compIf) d
 
-fromIR_dictItem :: DictItem a -> Validation (NonEmpty (IRError a)) (Syntax.DictItem '[] a)
+fromIR_dictItem
+  :: AsIRError e a
+  => DictItem a
+  -> Validation (NonEmpty e) (Syntax.DictItem '[] a)
 fromIR_dictItem di =
   case di of
     DictItem a b c d ->
@@ -766,7 +798,10 @@ fromIR_dictItem di =
     DictUnpack a b c ->
       Syntax.DictUnpack a b <$> fromIR_expr c
 
-fromIR_subscript :: Subscript a -> Validation (NonEmpty (IRError a)) (Syntax.Subscript '[] a)
+fromIR_subscript
+  :: AsIRError e a
+  => Subscript a
+  -> Validation (NonEmpty e) (Syntax.Subscript '[] a)
 fromIR_subscript s =
   case s of
     SubscriptExpr a -> Syntax.SubscriptExpr <$> fromIR_expr a
@@ -776,31 +811,44 @@ fromIR_subscript s =
       traverse fromIR_expr c <*>
       traverseOf (traverse._2.traverse) fromIR_expr d
 
-fromIR_block :: Block a -> Validation (NonEmpty (IRError a)) (Syntax.Block '[] a)
+fromIR_block
+  :: AsIRError e a
+  => Block a
+  -> Validation (NonEmpty e) (Syntax.Block '[] a)
 fromIR_block (Block a b c) =
   Syntax.Block a <$>
   fromIR_statement b <*>
   traverseOf (traverse.traverse) fromIR_statement c
 
-fromIR_compFor :: CompFor a -> Validation (NonEmpty (IRError a)) (Syntax.CompFor '[] a)
+fromIR_compFor
+  :: AsIRError e a
+  => CompFor a
+  -> Validation (NonEmpty e) (Syntax.CompFor '[] a)
 fromIR_compFor (CompFor a b c d e) =
   (\c' -> Syntax.CompFor a b c' d) <$>
   fromIR_expr c <*>
   fromIR_expr e
 
-fromIR_compIf :: CompIf a -> Validation (NonEmpty (IRError a)) (Syntax.CompIf '[] a)
+fromIR_compIf
+  :: AsIRError e a
+  => CompIf a
+  -> Validation (NonEmpty e) (Syntax.CompIf '[] a)
 fromIR_compIf (CompIf a b c) =
   Syntax.CompIf a b <$> fromIR_expr c
 
 fromIR_simpleStatement
-  :: SimpleStatement a
-  -> Validation (NonEmpty (IRError a)) (Syntax.SimpleStatement '[] a)
+  :: AsIRError e a
+  => SimpleStatement a
+  -> Validation (NonEmpty e) (Syntax.SimpleStatement '[] a)
 fromIR_simpleStatement (MkSimpleStatement b c d e f) =
   (\b' c' -> Syntax.MkSimpleStatement b' c' d e f) <$>
   fromIR_smallStatement b <*>
   traverseOf (traverse._2) fromIR_smallStatement c
 
-fromIR_statement :: Statement a -> Validation (NonEmpty (IRError a)) (Syntax.Statement '[] a)
+fromIR_statement
+  :: AsIRError e a
+  => Statement a
+  -> Validation (NonEmpty e) (Syntax.Statement '[] a)
 fromIR_statement ex =
   case ex of
     SimpleStatement i a ->
@@ -808,7 +856,10 @@ fromIR_statement ex =
     CompoundStatement a ->
       Syntax.CompoundStatement <$> fromIR_compoundStatement a
 
-fromIR_smallStatement :: SmallStatement a -> Validation (NonEmpty (IRError a)) (Syntax.SmallStatement '[] a)
+fromIR_smallStatement
+  :: AsIRError e a
+  => SmallStatement a
+  -> Validation (NonEmpty e) (Syntax.SmallStatement '[] a)
 fromIR_smallStatement ex =
   case ex of
     Assign a b c ->
@@ -842,8 +893,9 @@ fromIR_smallStatement ex =
       traverseOf (traverse._2) fromIR_expr d
 
 fromIR_compoundStatement
-  :: CompoundStatement a
-  -> Validation (NonEmpty (IRError a)) (Syntax.CompoundStatement '[] a)
+  :: AsIRError e a
+  => CompoundStatement a
+  -> Validation (NonEmpty e) (Syntax.CompoundStatement '[] a)
 fromIR_compoundStatement st =
   case st of
     Fundef a b asyncWs c d e f g h i j ->
@@ -889,7 +941,10 @@ fromIR_compoundStatement st =
       traverse fromIR_withItem d <*>
       fromIR_suite e
 
-fromIR_listItem :: Expr a -> Validation (NonEmpty (IRError a)) (Syntax.ListItem '[] a)
+fromIR_listItem
+  :: AsIRError e a
+  => Expr a
+  -> Validation (NonEmpty e) (Syntax.ListItem '[] a)
 fromIR_listItem (StarExpr a b c) =
   Syntax.ListUnpack a [] b <$> fromIR_expr c
 fromIR_listItem (Parens a b c d) =
@@ -899,7 +954,10 @@ fromIR_listItem (Parens a b c d) =
   fromIR_listItem c
 fromIR_listItem e = (\x -> Syntax.ListItem (x ^. Syntax.exprAnn) x) <$> fromIR_expr e
 
-fromIR_tupleItem :: Expr a -> Validation (NonEmpty (IRError a)) (Syntax.TupleItem '[] a)
+fromIR_tupleItem
+  :: AsIRError e a
+  => Expr a
+  -> Validation (NonEmpty e) (Syntax.TupleItem '[] a)
 fromIR_tupleItem (StarExpr a b c) =
   Syntax.TupleUnpack a [] b <$> fromIR_expr c
 fromIR_tupleItem (Parens a b c d) =
@@ -910,7 +968,10 @@ fromIR_tupleItem (Parens a b c d) =
 fromIR_tupleItem e =
   (\x -> Syntax.TupleItem (x ^. Syntax.exprAnn) x) <$> fromIR_expr e
 
-fromIR_setItem :: Expr a -> Validation (NonEmpty (IRError a)) (Syntax.SetItem '[] a)
+fromIR_setItem
+  :: AsIRError e a
+  => Expr a
+  -> Validation (NonEmpty e) (Syntax.SetItem '[] a)
 fromIR_setItem (StarExpr a b c) =
   Syntax.SetUnpack a [] b <$> fromIR_expr c
 fromIR_setItem (Parens a b c d) =
@@ -920,7 +981,10 @@ fromIR_setItem (Parens a b c d) =
   fromIR_setItem c
 fromIR_setItem e = (\x -> Syntax.SetItem (x ^. Syntax.exprAnn) x) <$> fromIR_expr e
 
-fromIR :: Module a -> Validation (NonEmpty (IRError a)) (Syntax.Module '[] a)
+fromIR
+  :: AsIRError e a
+  => Module a
+  -> Validation (NonEmpty e) (Syntax.Module '[] a)
 fromIR ModuleEmpty = pure Syntax.ModuleEmpty
 fromIR (ModuleBlankFinal a) = pure $ Syntax.ModuleBlankFinal a
 fromIR (ModuleBlank a b c) = Syntax.ModuleBlank a b <$> fromIR c

--- a/src/Language/Python/Optics.hs
+++ b/src/Language/Python/Optics.hs
@@ -1,4 +1,6 @@
 {-# language DataKinds #-}
+{-# language FunctionalDependencies, MultiParamTypeClasses #-}
+{-# language FlexibleInstances #-}
 {-# language PolyKinds #-}
 {-# language LambdaCase #-}
 
@@ -25,6 +27,7 @@ import Data.Function ((&))
 
 import Language.Python.Optics.Validated (unvalidated)
 import Language.Python.Syntax.Expr (Expr (..), TupleItem (TupleUnpack), ListItem (ListUnpack), Param (..), _Exprs)
+import Language.Python.Internal.Token (PyToken(..))
 import Language.Python.Internal.Syntax.Ident
 import Language.Python.Syntax.Module
 import Language.Python.Syntax.Statement (Block (..), CompoundStatement (..), Decorator (..), ExceptAs (..), SimpleStatement (..), Statement (..), Suite (..), _Statements)
@@ -244,42 +247,47 @@ _With =
 _Ident :: Prism (Expr v a) (Expr '[] a) (Ident v a) (Ident '[] a)
 _Ident =
   prism
-    (\a -> Ident a)
+    Ident
     (\case
         Ident a -> Right a
         a -> Left $ a ^. unvalidated)
 
-_Indent :: HasIndents s => Traversal' (s '[] a) [Whitespace]
+_Indent :: HasIndents s a => Traversal' s [Whitespace]
 _Indent = _Indents.indentsValue.traverse.indentWhitespaces
 
-noIndents :: HasIndents s => Fold (s '[] a) (s '[] a)
+noIndents :: HasIndents s a => Fold s s
 noIndents f s = f $ s & _Indents.indentsValue .~ []
 
-class HasIndents s where
-  _Indents :: Traversal' (s '[] a) (Indents a)
+class HasIndents s a | s -> a where
+  _Indents :: Traversal' s (Indents a)
 
-instance HasIndents Fundef where
+instance HasIndents (PyToken a) a where
+  _Indents f (TkIndent a i) = TkIndent a <$> f i
+  _Indents f (TkLevel a i) = TkLevel a <$> f i
+  _Indents _ a = pure a
+
+instance HasIndents (Fundef '[] a) a where
   _Indents fun (MkFundef a b c d e f g h i j k) =
     (\b' c' -> MkFundef a b' c' d e f g h i j) <$>
     (traverse._Indents) fun b <*>
     fun c <*>
     _Indents fun k
 
-instance HasIndents For where
+instance HasIndents (For '[] a) a where
   _Indents fun (MkFor a b c d e f g h i) =
     (\b' -> MkFor a b' c d e f g) <$>
     fun b <*>
     _Indents fun h <*>
     (traverse._Indents) fun i
 
-instance HasIndents TryFinally where
+instance HasIndents (TryFinally '[] a) a where
   _Indents fun (MkTryFinally a b c d e) =
     (\b' -> MkTryFinally a b' c) <$>
     fun b <*>
     _Indents fun d <*>
     _Indents fun e
 
-instance HasIndents TryExcept where
+instance HasIndents (TryExcept '[] a) a where
   _Indents fun (MkTryExcept a b c d e f g) =
     (\b' -> MkTryExcept a b' c) <$>
     fun b <*>
@@ -288,19 +296,19 @@ instance HasIndents TryExcept where
     (traverse._Indents) fun f <*>
     (traverse._Indents) fun g
 
-instance HasIndents Except where
+instance HasIndents (Except '[] a) a where
   _Indents fun (MkExcept a b c d) =
     (\a' -> MkExcept a' b c) <$>
     fun a <*>
     _Indents fun d
 
-instance HasIndents Finally where
+instance HasIndents (Finally '[] a) a where
   _Indents fun (MkFinally a b c) =
     (\a' -> MkFinally a' b) <$>
     fun a <*>
     _Indents fun c
 
-instance HasIndents If where
+instance HasIndents (If '[] a) a where
   _Indents fun (MkIf a b c d e f g) =
     (\b' -> MkIf a b' c d) <$>
     fun b <*>
@@ -308,56 +316,56 @@ instance HasIndents If where
     (traverse._Indents) fun f <*>
     (traverse._Indents) fun g
 
-instance HasIndents While where
+instance HasIndents (While '[] a) a where
   _Indents fun (MkWhile a b c d e f) =
     (\b' -> MkWhile a b' c d) <$>
     fun b <*>
     _Indents fun e <*>
     (traverse._Indents) fun f
 
-instance HasIndents Elif where
+instance HasIndents (Elif '[] a) a where
   _Indents fun (MkElif a b c d) =
     (\a' -> MkElif a' b c) <$>
     fun a <*>
     _Indents fun d
 
-instance HasIndents Else where
+instance HasIndents (Else '[] a) a where
   _Indents f (MkElse a b c) = MkElse <$> f a <*> pure b <*> _Indents f c
 
-instance HasIndents SimpleStatement where
+instance HasIndents (SimpleStatement '[] a) a where
   _Indents _ (MkSimpleStatement a b c d e) =
     pure $ MkSimpleStatement a b c d e
 
-instance HasIndents Statement where
+instance HasIndents (Statement '[] a) a where
   _Indents f (SimpleStatement idnt a) = SimpleStatement <$> f idnt <*> _Indents f a
   _Indents f (CompoundStatement c) = CompoundStatement <$> _Indents f c
 
-instance HasIndents Block where
+instance HasIndents (Block '[] a) a where
   _Indents = _Statements._Indents
 
-instance HasIndents Suite where
+instance HasIndents (Suite '[] a) a where
   _Indents _ (SuiteOne a b c) = pure $ SuiteOne a b c
   _Indents f (SuiteMany a b c d e) = SuiteMany a b c d <$> _Indents f e
 
-instance HasIndents Decorator where
+instance HasIndents (Decorator '[] a) a where
   _Indents fun (Decorator a b c d e f g) =
     (\b' -> Decorator a b' c d e f g) <$>
     fun b
 
-instance HasIndents ClassDef where
+instance HasIndents (ClassDef '[] a) a where
   _Indents fun (MkClassDef a b c d e f g) =
     (\b' c' -> MkClassDef a b' c' d e f) <$>
     (traverse._Indents) fun b <*>
     fun c <*>
     _Indents fun g
 
-instance HasIndents With where
+instance HasIndents (With '[] a) a where
   _Indents fun (MkWith a b c d e f) =
     (\b' -> MkWith a b' c d e) <$>
     fun b <*>
     _Indents fun f
 
-instance HasIndents CompoundStatement where
+instance HasIndents (CompoundStatement '[] a) a where
   _Indents fun s =
     case s of
       Fundef a decos idnt asyncWs b c d e f g h ->

--- a/src/Language/Python/Parse.hs
+++ b/src/Language/Python/Parse.hs
@@ -1,5 +1,6 @@
 {-# language DataKinds #-}
-{-# language TemplateHaskell #-}
+{-# language FlexibleContexts #-}
+{-# language MultiParamTypeClasses, FlexibleInstances #-}
 
 {-|
 Module      : Language.Python.Parse
@@ -11,129 +12,114 @@ Portability : non-portable
 -}
 
 module Language.Python.Parse
-  ( SrcInfo(..)
-  , initialSrcInfo
-  , ParseError(..)
-  , ErrorItem(..)
-  , Parse.Parser
+  ( Parser
   , parseModule
   , parseStatement
   , parseExpr
   , parseExprList
-    -- * Optics
-  , _LexicalError
-  , _ParseError
-  , _TabError
-  , _IncorrectDedent
-  , _ExpectedDedent
-  , _InvalidUnpacking
+    -- * Source Information
+  , SrcInfo(..), initialSrcInfo
   )
 where
 
 import Control.Applicative ((<|>))
-import Control.Lens.TH (makePrisms)
 import Data.Bifunctor (first)
 import Data.List.NonEmpty (NonEmpty)
-import Data.Set (Set)
 import Data.Text (Text)
 import Data.Validation (Validation, bindValidation, fromEither)
 import Data.Void (Void)
 import Text.Megaparsec (eof)
-import Text.Megaparsec.Error (ErrorItem(..))
-import Text.Megaparsec.Pos (SourcePos(..))
 
 import Language.Python.Internal.Lexer
-  (SrcInfo(..), initialSrcInfo, withSrcInfo, tokenize, insertTabs)
+  ( AsLexicalError(..), AsTabError(..)
+  , SrcInfo(..), initialSrcInfo, withSrcInfo
+  , tokenize, insertTabs
+  )
 import Language.Python.Internal.Token (PyToken)
+import Language.Python.Internal.Parse
+  (AsParseError, Parser, runParser, level, module_, statement, exprList, expr, space)
 import Language.Python.Syntax.Expr (Expr)
+import Language.Python.Internal.Syntax.IR (AsIRError)
 import Language.Python.Syntax.Module (Module)
 import Language.Python.Syntax.Statement (Statement)
 import Language.Python.Syntax.Whitespace (Indents (..))
 
-import qualified Text.Megaparsec.Error as Megaparsec
-import qualified Language.Python.Internal.Lexer as Lexer
-import qualified Language.Python.Internal.Parse as Parse
 import qualified Language.Python.Internal.Syntax.IR as IR
 
-data ParseError a
-  = LexicalError
-      (NonEmpty SourcePos)
-      (Maybe (ErrorItem Char))
-      (Set (ErrorItem Char))
-  | ParseError
-      (NonEmpty SourcePos)
-      (Maybe (ErrorItem (PyToken a)))
-      (Set (ErrorItem (PyToken a)))
-  | TabError a
-  | IncorrectDedent a
-  | ExpectedDedent a
-  | InvalidUnpacking a
-  deriving (Eq, Show)
-makePrisms ''ParseError
-
-fromLexicalError :: Megaparsec.ParseError Char Void -> ParseError SrcInfo
-fromLexicalError Megaparsec.FancyError{} = error "there are none of these"
-fromLexicalError (Megaparsec.TrivialError pos a b) = LexicalError pos a b
-
-fromTabError :: Lexer.TabError a -> ParseError a
-fromTabError e =
-  case e of
-    Lexer.TabError a -> TabError a
-    Lexer.IncorrectDedent a -> IncorrectDedent a
-
-fromParseError :: Megaparsec.ParseError (PyToken SrcInfo) Void -> ParseError SrcInfo
-fromParseError Megaparsec.FancyError{} = error "there are none of these"
-fromParseError (Megaparsec.TrivialError pos a b) = ParseError pos a b
-
-fromIRError :: IR.IRError a -> ParseError a
-fromIRError e =
-  case e of
-    IR.InvalidUnpacking a -> InvalidUnpacking a
-
-parseModule :: FilePath -> Text -> Validation (NonEmpty (ParseError SrcInfo)) (Module '[] SrcInfo)
+parseModule
+  :: ( AsLexicalError e Char Void
+     , AsTabError e SrcInfo
+     , AsParseError e (PyToken SrcInfo) Void
+     , AsIRError e SrcInfo
+     )
+  => FilePath
+  -> Text
+  -> Validation (NonEmpty e) (Module '[] SrcInfo)
 parseModule fp input =
   let
     si = initialSrcInfo fp
     ir = do
-      tokens <- first fromLexicalError $ tokenize fp input
-      tabbed <- first fromTabError $ insertTabs si tokens
-      first fromParseError $ Parse.runParser fp Parse.module_ tabbed
+      tokens <- tokenize fp input
+      tabbed <- insertTabs si tokens
+      runParser fp module_ tabbed
   in
-    fromEither (first pure ir) `bindValidation` (first (fmap fromIRError) . IR.fromIR)
+    fromEither (first pure ir) `bindValidation` IR.fromIR
 
-parseStatement :: FilePath -> Text -> Validation (NonEmpty (ParseError SrcInfo)) (Statement '[] SrcInfo)
+parseStatement
+  :: ( AsLexicalError e Char Void
+     , AsTabError e SrcInfo
+     , AsParseError e (PyToken SrcInfo) Void
+     , AsIRError e SrcInfo
+     )
+  => FilePath
+  -> Text
+  -> Validation (NonEmpty e) (Statement '[] SrcInfo)
 parseStatement fp input =
   let
     si = initialSrcInfo fp
     ir = do
-      tokens <- first fromLexicalError $ tokenize fp input
-      tabbed <- first fromTabError $ insertTabs si tokens
-      first fromParseError $
-        Parse.runParser fp ((Parse.statement tlIndent =<< tlIndent) <* eof) tabbed
+      tokens <- tokenize fp input
+      tabbed <- insertTabs si tokens
+      runParser fp ((statement tlIndent =<< tlIndent) <* eof) tabbed
   in
-    fromEither (first pure ir) `bindValidation`
-    (first (fmap fromIRError) . IR.fromIR_statement)
+    fromEither (first pure ir) `bindValidation` IR.fromIR_statement
   where
-    tlIndent = Parse.level <|> withSrcInfo (pure $ Indents [])
+    tlIndent = level <|> withSrcInfo (pure $ Indents [])
 
-parseExprList :: FilePath -> Text -> Validation (NonEmpty (ParseError SrcInfo)) (Expr '[] SrcInfo)
+parseExprList
+  :: ( AsLexicalError e Char Void
+     , AsTabError e SrcInfo
+     , AsParseError e (PyToken SrcInfo) Void
+     , AsIRError e SrcInfo
+     )
+  => FilePath
+  -> Text
+  -> Validation (NonEmpty e) (Expr '[] SrcInfo)
 parseExprList fp input =
   let
     si = initialSrcInfo fp
     ir = do
-      tokens <- first fromLexicalError $ tokenize fp input
-      tabbed <- first fromTabError $ insertTabs si tokens
-      first fromParseError $ Parse.runParser fp (Parse.exprList Parse.space <* eof) tabbed
+      tokens <- tokenize fp input
+      tabbed <- insertTabs si tokens
+      runParser fp (exprList space <* eof) tabbed
   in
-    fromEither (first pure ir) `bindValidation` (first (fmap fromIRError) . IR.fromIR_expr)
+    fromEither (first pure ir) `bindValidation` IR.fromIR_expr
 
-parseExpr :: FilePath -> Text -> Validation (NonEmpty (ParseError SrcInfo)) (Expr '[] SrcInfo)
+parseExpr
+  :: ( AsLexicalError e Char Void
+     , AsTabError e SrcInfo
+     , AsParseError e (PyToken SrcInfo) Void
+     , AsIRError e SrcInfo
+     )
+  => FilePath
+  -> Text
+  -> Validation (NonEmpty e) (Expr '[] SrcInfo)
 parseExpr fp input =
   let
     si = initialSrcInfo fp
     ir = do
-      tokens <- first fromLexicalError $ tokenize fp input
-      tabbed <- first fromTabError $ insertTabs si tokens
-      first fromParseError $ Parse.runParser fp (Parse.expr Parse.space <* eof) tabbed
+      tokens <- tokenize fp input
+      tabbed <- insertTabs si tokens
+      runParser fp (expr space <* eof) tabbed
   in
-    fromEither (first pure ir) `bindValidation` (first (fmap fromIRError) . IR.fromIR_expr)
+    fromEither (first pure ir) `bindValidation` IR.fromIR_expr

--- a/src/Language/Python/Parse.hs
+++ b/src/Language/Python/Parse.hs
@@ -47,7 +47,7 @@ import Language.Python.Syntax.Whitespace (Indents (..))
 import qualified Language.Python.Internal.Syntax.IR as IR
 
 parseModule
-  :: ( AsLexicalError e Char Void
+  :: ( AsLexicalError e Char
      , AsTabError e SrcInfo
      , AsParseError e (PyToken SrcInfo) Void
      , AsIRError e SrcInfo
@@ -66,7 +66,7 @@ parseModule fp input =
     fromEither (first pure ir) `bindValidation` IR.fromIR
 
 parseStatement
-  :: ( AsLexicalError e Char Void
+  :: ( AsLexicalError e Char
      , AsTabError e SrcInfo
      , AsParseError e (PyToken SrcInfo) Void
      , AsIRError e SrcInfo
@@ -87,7 +87,7 @@ parseStatement fp input =
     tlIndent = level <|> withSrcInfo (pure $ Indents [])
 
 parseExprList
-  :: ( AsLexicalError e Char Void
+  :: ( AsLexicalError e Char
      , AsTabError e SrcInfo
      , AsParseError e (PyToken SrcInfo) Void
      , AsIRError e SrcInfo
@@ -106,7 +106,7 @@ parseExprList fp input =
     fromEither (first pure ir) `bindValidation` IR.fromIR_expr
 
 parseExpr
-  :: ( AsLexicalError e Char Void
+  :: ( AsLexicalError e Char
      , AsTabError e SrcInfo
      , AsParseError e (PyToken SrcInfo) Void
      , AsIRError e SrcInfo

--- a/src/Language/Python/Parse/Error.hs
+++ b/src/Language/Python/Parse/Error.hs
@@ -1,0 +1,76 @@
+{-# language FlexibleInstances, MultiParamTypeClasses #-}
+{-# language LambdaCase #-}
+module Language.Python.Parse.Error
+  ( ParseError(..)
+    -- * Classy Prisms
+  , AsLexicalError(..), AsTabError(..), AsIRError(..), AsParseError(..)
+    -- * Megaparsec re-exports
+  , ErrorItem(..)
+  , SourcePos(..)
+  )
+where
+
+import Control.Lens.Prism (prism')
+import Data.Set (Set)
+import Data.List.NonEmpty (NonEmpty)
+import Data.Void (Void)
+import Text.Megaparsec.Error (ErrorItem(..))
+import Text.Megaparsec.Pos (SourcePos(..))
+
+import Language.Python.Internal.Lexer (AsLexicalError(..), AsTabError(..))
+import Language.Python.Internal.Parse (AsParseError(..))
+import Language.Python.Internal.Syntax.IR (AsIRError(..))
+import Language.Python.Internal.Token (PyToken)
+
+data ParseError a
+  = LexicalError
+      (NonEmpty SourcePos)
+      (Maybe (ErrorItem Char))
+      (Set (ErrorItem Char))
+  | ParseError
+      (NonEmpty SourcePos)
+      (Maybe (ErrorItem (PyToken a)))
+      (Set (ErrorItem (PyToken a)))
+  | TabError a
+  | IncorrectDedent a
+  | ExpectedDedent a
+  | InvalidUnpacking a
+  deriving (Eq, Show)
+
+instance AsLexicalError (ParseError a) Char Void where
+  _LexicalError =
+    prism'
+      (\(a, b, c) -> LexicalError a b c)
+      (\case
+          LexicalError a b c -> Just (a, b ,c)
+          _ -> Nothing)
+
+instance AsTabError (ParseError a) a where
+  _TabError =
+    prism'
+      TabError
+      (\case
+          TabError a -> Just a
+          _ -> Nothing)
+  _IncorrectDedent =
+    prism'
+      IncorrectDedent
+      (\case
+          IncorrectDedent a -> Just a
+          _ -> Nothing)
+
+instance AsParseError (ParseError a) (PyToken a) Void where
+  _ParseError =
+    prism'
+      (\(a, b, c) -> ParseError a b c)
+      (\case
+          ParseError a b c -> Just (a, b ,c)
+          _ -> Nothing)
+
+instance AsIRError (ParseError a) a where
+  _InvalidUnpacking =
+    prism'
+      InvalidUnpacking
+      (\case
+          InvalidUnpacking a -> Just a
+          _ -> Nothing)

--- a/src/Language/Python/Parse/Error.hs
+++ b/src/Language/Python/Parse/Error.hs
@@ -37,7 +37,7 @@ data ParseError a
   | InvalidUnpacking a
   deriving (Eq, Show)
 
-instance AsLexicalError (ParseError a) Char Void where
+instance AsLexicalError (ParseError a) Char where
   _LexicalError =
     prism'
       (\(a, b, c) -> LexicalError a b c)

--- a/test/LexerParser.hs
+++ b/test/LexerParser.hs
@@ -3,7 +3,6 @@ module LexerParser (lexerParserTests) where
 
 import Hedgehog
 import Control.Monad (void)
-import Data.Validation (Validation(..), validation)
 import qualified Data.Text as Text
 
 import Language.Python.Render
@@ -14,7 +13,7 @@ import Language.Python.Internal.Syntax.Strings
   , RawBytesPrefix(..), RawStringPrefix(..)
   )
 
-import Helpers (shouldBeSuccess)
+import Helpers (shouldBeParseSuccess, shouldBeParseFailure)
 
 lexerParserTests :: Group
 lexerParserTests = $$discover
@@ -24,8 +23,7 @@ prop_fulltrip_1 =
   withTests 1 . property $ do
     let str = "def a(x, y=2, *z, **w):\n   return 2 + 3"
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseStatement "test" str
-    annotateShow tree
+    tree <- shouldBeParseSuccess parseStatement str
 
     showStatement tree === str
 
@@ -34,8 +32,7 @@ prop_fulltrip_2 =
   withTests 1 . property $ do
     let str = "(   1\n       *\n  3\n    )"
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseExpr "test" str
-    annotateShow tree
+    tree <- shouldBeParseSuccess parseExpr str
 
     showExpr tree === str
 
@@ -44,8 +41,7 @@ prop_fulltrip_3 =
   withTests 1 . property $ do
     let str = "pass;"
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseStatement "test" str
-    annotateShow tree
+    tree <- shouldBeParseSuccess parseStatement str
 
     showStatement tree === str
 
@@ -54,8 +50,7 @@ prop_fulltrip_4 =
   withTests 1 . property $ do
     let str = "def a():\n pass\n #\n pass\n"
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseStatement "test" str
-    annotateShow tree
+    tree <- shouldBeParseSuccess parseStatement str
 
     showStatement tree === str
 
@@ -64,8 +59,7 @@ prop_fulltrip_5 =
   withTests 1 . property $ do
     let str = "if False:\n pass\n pass\nelse:\n pass\n pass\n"
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseStatement "test" str
-    annotateShow tree
+    tree <- shouldBeParseSuccess parseStatement str
 
     showStatement tree === str
 
@@ -74,8 +68,7 @@ prop_fulltrip_6 =
   withTests 1 . property $ do
     let str = "# blah\ndef boo():\n    pass\n       #bing\n    #   bop\n"
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseModule "test" str
-    annotateShow tree
+    tree <- shouldBeParseSuccess parseModule str
 
     showModule tree === str
 
@@ -84,8 +77,7 @@ prop_fulltrip_7 =
   withTests 1 . property $ do
     let str = "if False:\n pass\nelse \\\n      \\\r\n:\n pass\n"
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseModule "test" str
-    annotateShow tree
+    tree <- shouldBeParseSuccess parseModule str
 
     showModule tree === str
 
@@ -94,8 +86,7 @@ prop_fulltrip_8 =
   withTests 1 . property $ do
     let str = "def a():\n \n pass\n pass\n"
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseModule "test" str
-    annotateShow tree
+    tree <- shouldBeParseSuccess parseModule str
 
     showModule tree === str
 
@@ -106,8 +97,7 @@ prop_fulltrip_9 =
       str =
         "try:\n pass\nexcept False:\n pass\nelse:\n pass\nfinally:\n pass\n def a():\n  pass\n pass\n"
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseModule "test" str
-    annotateShow tree
+    tree <- shouldBeParseSuccess parseModule str
 
     showModule tree === str
 
@@ -130,8 +120,7 @@ prop_fulltrip_10 =
         , "    pass"
         ]
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseModule "test" str
-    annotateShow $! tree
+    tree <- shouldBeParseSuccess parseModule str
 
     showModule tree === str
 
@@ -149,8 +138,7 @@ prop_fulltrip_11 =
         , " \tpass"
         ]
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseModule "test" str
-    annotateShow $! tree
+    tree <- shouldBeParseSuccess parseModule str
 
     showModule tree === str
 
@@ -169,8 +157,7 @@ prop_fulltrip_12 =
         , " pass"
         ]
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseModule "test" str
-    annotateShow $! tree
+    tree <- shouldBeParseSuccess parseModule str
 
     showModule tree === str
 
@@ -191,8 +178,7 @@ prop_fulltrip_13 =
         , " pass"
         ]
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseModule "test" str
-    annotateShow $! tree
+    tree <- shouldBeParseSuccess parseModule str
 
     showModule tree === str
 
@@ -202,8 +188,7 @@ prop_fulltrip_14 =
     let
       str = "not ((False for a in False) if False else False or False)"
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseModule "test" str
-    annotateShow $! tree
+    tree <- shouldBeParseSuccess parseModule str
 
     showModule tree === str
 
@@ -213,8 +198,7 @@ prop_fulltrip_15 =
     let
       str = "01."
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseModule "test" str
-    annotateShow $! tree
+    tree <- shouldBeParseSuccess parseModule str
 
     showModule tree === str
 
@@ -224,8 +208,7 @@ prop_fulltrip_16 =
     let
       str = "def a():\n  return ~i"
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseModule "test" str
-    annotateShow $! tree
+    tree <- shouldBeParseSuccess parseModule str
 
     showModule tree === str
 
@@ -234,8 +217,7 @@ prop_fulltrip_17 =
   withTests 1 . property $ do
     let str = "r\"\\\"\""
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseModule "test" str
-    annotateShow $! tree
+    tree <- shouldBeParseSuccess parseModule str
 
     showModule tree === str
 
@@ -244,8 +226,7 @@ prop_fulltrip_18 =
   withTests 1 . property $ do
     let str = "\"\0\""
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseModule "test" str
-    annotateShow $! tree
+    tree <- shouldBeParseSuccess parseModule str
 
     showModule tree === str
 
@@ -254,64 +235,49 @@ prop_fulltrip_19 =
   withTests 1 . property $ do
     let str = " \\\n"
 
-    let res = parseModule "test" str
-    case res of
-      Failure{} -> success
-      Success a -> do
-        annotateShow a
-        failure
+    shouldBeParseFailure parseModule str
 
 prop_fulltrip_20 :: Property
 prop_fulltrip_20 =
   withTests 1 . property $ do
     let str = " pass"
 
-    let res = parseModule "test" str
-    case res of
-      Failure{} -> success
-      Success a -> do
-        annotateShow a
-        failure
+    shouldBeParseFailure parseModule str
 
 prop_fulltrip_21 :: Property
 prop_fulltrip_21 =
   withTests 1 . property $ do
     let str = "if a:\n  \\\n\n  pass"
 
-    let res = parseModule "test" str
-    case res of
-      Failure{} -> success
-      Success a -> do
-        annotateShow a
-        failure
+    shouldBeParseFailure parseModule str
 
 prop_fulltrip_22 :: Property
 prop_fulltrip_22 =
   withTests 1 . property $ do
     let str = "for a in (b, *c): pass"
 
-    void . shouldBeSuccess $ parseModule "test" str
+    void $ shouldBeParseSuccess parseModule str
 
 prop_fulltrip_23 :: Property
 prop_fulltrip_23 =
   withTests 1 . property $ do
     let str = "None,*None"
 
-    void . shouldBeSuccess $ parseModule "test" str
+    void $ shouldBeParseSuccess parseModule str
 
 prop_fulltrip_24 :: Property
 prop_fulltrip_24 =
   withTests 1 . property $ do
     let str = "'\1'"
 
-    void . shouldBeSuccess $ parseModule "test" str
+    void $ shouldBeParseSuccess parseModule str
 
 prop_fulltrip_25 :: Property
 prop_fulltrip_25 =
   withTests 1 . property $ do
     let str = "'\11'"
 
-    void . shouldBeSuccess $ parseModule "test" str
+    void $ shouldBeParseSuccess parseModule str
 
 prop_fulltrip_26 :: Property
 prop_fulltrip_26 =
@@ -328,7 +294,7 @@ prop_fulltrip_26 =
                [])
     annotateShow str
 
-    res <- shouldBeSuccess $ parseExpr "test" str
+    res <- shouldBeParseSuccess parseExpr str
     str === showExpr (() <$ res)
 
 prop_fulltrip_27 :: Property
@@ -346,7 +312,7 @@ prop_fulltrip_27 =
                [])
     annotateShow str
 
-    res <- shouldBeSuccess $ parseExpr "test" str
+    res <- shouldBeParseSuccess parseExpr str
     str === showExpr (() <$ res)
 
 prop_fulltrip_28 :: Property
@@ -364,7 +330,7 @@ prop_fulltrip_28 =
                [])
     annotateShow str
 
-    res <- shouldBeSuccess $ parseExpr "test" str
+    res <- shouldBeParseSuccess parseExpr str
     str === showExpr (() <$ res)
 
 prop_fulltrip_29 :: Property
@@ -382,7 +348,7 @@ prop_fulltrip_29 =
                [])
     annotateShow str
 
-    res <- shouldBeSuccess $ parseExpr "test" str
+    res <- shouldBeParseSuccess parseExpr str
     str === showExpr (() <$ res)
 
 prop_fulltrip_30 :: Property
@@ -400,7 +366,7 @@ prop_fulltrip_30 =
                [])
     annotateShow str
 
-    res <- shouldBeSuccess $ parseExpr "test" str
+    res <- shouldBeParseSuccess parseExpr str
     str === showExpr (() <$ res)
 
 prop_fulltrip_31 :: Property
@@ -408,7 +374,7 @@ prop_fulltrip_31 =
   withTests 1 . property $ do
     let str = "del(a)"
 
-    void . shouldBeSuccess $ parseModule "test" str
+    void $ shouldBeParseSuccess parseModule str
 
 prop_fulltrip_32 :: Property
 prop_fulltrip_32 =
@@ -425,7 +391,7 @@ prop_fulltrip_32 =
                [])
     annotateShow str
 
-    res <- shouldBeSuccess $ parseExpr "test" str
+    res <- shouldBeParseSuccess parseExpr str
     str === showExpr (() <$ res)
 
 prop_fulltrip_33 :: Property
@@ -443,7 +409,7 @@ prop_fulltrip_33 =
                [])
     annotateShow str
 
-    res <- shouldBeSuccess $ parseExpr "test" str
+    res <- shouldBeParseSuccess parseExpr "test"
     str === showExpr (() <$ res)
 
 prop_fulltrip_34 :: Property
@@ -461,5 +427,5 @@ prop_fulltrip_34 =
                [])
     annotateShow str
 
-    res <- shouldBeSuccess $ parseExpr "test" str
+    res <- shouldBeParseSuccess parseExpr str
     str === showExpr (() <$ res)

--- a/test/Optics.hs
+++ b/test/Optics.hs
@@ -6,7 +6,6 @@ import Hedgehog
 import Control.Lens.Plated (transformOn)
 import Control.Lens.Setter ((.~))
 import Control.Monad.IO.Class (liftIO)
-import Data.Validation (validation)
 import qualified Data.Text.IO as Text
 
 import Language.Python.Parse (parseModule)
@@ -14,6 +13,8 @@ import Language.Python.Render (showModule)
 import Language.Python.Syntax.Statement (_Statements)
 import Language.Python.Syntax.Whitespace (Whitespace (..))
 import Language.Python.Optics (_Indent)
+
+import Helpers (shouldBeParseSuccess)
 
 opticsTests :: Group
 opticsTests = $$discover
@@ -23,8 +24,7 @@ prop_optics_1 =
   withTests 1 . property $ do
     str <- liftIO $ Text.readFile "test/files/indent_optics_in.py"
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseModule "test" str
-    -- annotateShow $! tree
+    tree <- shouldBeParseSuccess parseModule str
 
     str' <- liftIO $ Text.readFile "test/files/indent_optics_out.py"
     showModule
@@ -35,7 +35,7 @@ prop_optics_2 =
   withTests 1 . property $ do
     str <- liftIO $ Text.readFile "test/files/indent_optics_in2.py"
 
-    tree <- validation (\e -> annotateShow e *> failure) pure $ parseModule "test" str
+    tree <- shouldBeParseSuccess parseModule str
     -- annotateShow $! tree
 
     str' <- liftIO $ Text.readFile "test/files/indent_optics_out2.py"

--- a/test/Roundtrip.hs
+++ b/test/Roundtrip.hs
@@ -6,7 +6,7 @@ import Control.Monad.IO.Class (liftIO)
 import Data.List.NonEmpty (NonEmpty)
 import Data.String (fromString)
 import Data.Text (Text)
-import Data.Validation (Validation(..), validation)
+import Data.Validation (Validation(..))
 import Hedgehog
   ( (===), Group(..), Property, PropertyT, annotateShow, failure, property
   , withTests, withShrinks
@@ -19,7 +19,13 @@ import qualified Data.Text.IO as StrictText
 import Language.Python.Internal.Lexer (SrcInfo)
 import Language.Python.Render (showModule)
 import Language.Python.Parse (parseModule)
-import Language.Python.Validate (Indentation, IndentationError, SyntaxError, runValidateIndentation, validateModuleIndentation, runValidateSyntax, validateModuleSyntax, initialSyntaxContext)
+import Language.Python.Validate
+  ( Indentation, IndentationError, SyntaxError
+  , runValidateIndentation, validateModuleIndentation, runValidateSyntax
+  , validateModuleSyntax, initialSyntaxContext
+  )
+
+import Helpers (shouldBeParseSuccess)
 
 roundtripTests :: Group
 roundtripTests =
@@ -63,7 +69,7 @@ doRoundtripFile name =
 
 doRoundtrip :: Text -> PropertyT IO ()
 doRoundtrip file = do
-  py <- validation (\e -> annotateShow e *> failure) pure $ parseModule "test" file
+  py <- shouldBeParseSuccess parseModule file
   case runValidateIndentation $ validateModuleIndentation py of
     Failure errs -> do
       annotateShow (errs :: NonEmpty (IndentationError '[] SrcInfo))

--- a/test/Syntax.hs
+++ b/test/Syntax.hs
@@ -16,7 +16,9 @@ import Language.Python.Syntax.Statement
 import Language.Python.Syntax.Whitespace
 
 import Helpers
-  (shouldBeFailure, shouldBeSuccess, syntaxValidateExpr, syntaxValidateModule)
+  ( shouldBeParseSuccess, shouldBeFailure, shouldBeSuccess
+  , syntaxValidateExpr, syntaxValidateModule
+  )
 
 syntaxTests :: Group
 syntaxTests = $$discover
@@ -55,8 +57,8 @@ prop_syntax_2 =
              MkSimpleStatement (Pass () []) [] Nothing Nothing Nothing)
             [Right . SimpleStatement (Indents [i] ()) $
              MkSimpleStatement (Pass () []) [] Nothing Nothing Nothing]
-    res <- shouldBeSuccess $ parseStatement "test" (showStatement e)
-    res' <- shouldBeSuccess $ parseStatement "test" (showStatement res)
+    res <- shouldBeParseSuccess parseStatement (showStatement e)
+    res' <- shouldBeParseSuccess parseStatement (showStatement res)
     void res === void res'
 
 prop_syntax_3 :: Property
@@ -64,7 +66,7 @@ prop_syntax_3 =
   withTests 1 . property $ do
     let
       s = "@a\ndef a():\n pass\n @a\n class a: return "
-    e <- shouldBeSuccess $ parseModule "test" s
+    e <- shouldBeParseSuccess parseModule s
     shouldBeFailure =<< syntaxValidateModule (() <$ e)
 
 prop_syntax_4 :: Property
@@ -79,8 +81,8 @@ prop_syntax_4 =
         ShortString SingleQuote
         [Char_lit '\\', Char_lit 'u']
         []
-    res <- shouldBeSuccess $ parseExpr "test" (showExpr e)
-    res' <- shouldBeSuccess $ parseExpr "test" (showExpr res)
+    res <- shouldBeParseSuccess parseExpr (showExpr e)
+    res' <- shouldBeParseSuccess parseExpr (showExpr res)
     void res === void res'
 
 prop_syntax_5 :: Property
@@ -95,13 +97,13 @@ prop_syntax_5 =
         ShortString SingleQuote
         [Char_lit '\\', Char_lit 'x']
         []
-    res <- shouldBeSuccess $ parseExpr "test" (showExpr e)
-    res' <- shouldBeSuccess $ parseExpr "test" (showExpr res)
+    res <- shouldBeParseSuccess parseExpr (showExpr e)
+    res' <- shouldBeParseSuccess parseExpr (showExpr res)
     void res === void res'
 
 prop_syntax_6 :: Property
 prop_syntax_6 =
   withTests 1 . property $ do
     let s= "async def a():\n class a(await None):\n  pass"
-    e <- shouldBeSuccess $ parseModule "test" s
+    e <- shouldBeParseSuccess parseModule s
     void . shouldBeSuccess =<< syntaxValidateModule (() <$ e)


### PR DESCRIPTION
`PyToken` now has a `HasIndents` instance, so `tokens & traverse._Indent .~ someSpaces` should be a file-wide re-indentation.

One obtains the fully processed token stream with `insertTabs . tokenize (initialSrcInfo fileName)` (modulo return types). These functions are in `Language.Python.Internal.Lexer`. Should I write a function that does that composition?

Any comments?