### PR TITLE
Add Comma data type

### DIFF
--- a/example/Programs.hs
+++ b/example/Programs.hs
@@ -9,7 +9,7 @@ import Data.List.NonEmpty (NonEmpty(..))
 
 import Language.Python.DSL
 import Language.Python.Syntax.Module (Module (..))
-import Language.Python.Syntax.CommaSep (CommaSep (..), CommaSep1' (..))
+import Language.Python.Syntax.CommaSep (Comma (..), CommaSep (..), CommaSep1' (..))
 import Language.Python.Syntax.Expr (Arg (..), Expr (..), Param (..))
 import Language.Python.Syntax.Statement (Block (..), CompoundStatement (..), SimpleStatement (..), SmallStatement (..), Statement (..), Suite (..))
 import Language.Python.Syntax.Whitespace (Blank (..), Indents (..), Newline (..), Whitespace (..), indentWhitespaces)
@@ -30,7 +30,7 @@ append_to =
     (Space :| [])
     "append_to"
     []
-    ( CommaSepMany (PositionalParam () "element" Nothing) [Space] $
+    ( CommaSepMany (PositionalParam () "element" Nothing) (Comma [Space]) $
       CommaSepOne (KeywordParam () "to" Nothing [] (List () [] Nothing []))
     )
     []

--- a/hpython-test/src/Generators/Common.hs
+++ b/hpython-test/src/Generators/Common.hs
@@ -371,6 +371,9 @@ genOp = Gen.element $ _opOperator <$> operatorTable
 genDot :: MonadGen m => m Dot
 genDot = Dot <$> genWhitespaces
 
+genComma :: MonadGen m => m Comma
+genComma = Comma <$> genWhitespaces
+
 genSizedCommaSep :: MonadGen m => m a -> m (CommaSep a)
 genSizedCommaSep ma = Gen.sized $ \n ->
   if n <= 1
@@ -384,7 +387,7 @@ genSizedCommaSep ma = Gen.sized $ \n ->
           a <- Gen.resize n' ma
           Gen.subtermM
             (Gen.resize (n - n') $ genSizedCommaSep ma)
-            (\b -> CommaSepMany a <$> genWhitespaces <*> pure b)
+            (\b -> CommaSepMany a <$> genComma <*> pure b)
       ]
 
 genSizedCommaSep1 :: MonadGen m => m a -> m (CommaSep1 a)
@@ -400,23 +403,23 @@ genSizedCommaSep1 ma = Gen.sized $ \n ->
           a <- Gen.resize n' ma
           Gen.subtermM
             (Gen.resize (n - n') $ genSizedCommaSep1 ma)
-            (\b -> CommaSepMany1 a <$> genWhitespaces <*> pure b)
+            (\b -> CommaSepMany1 a <$> genComma <*> pure b)
       ]
 
 genSizedCommaSep1' :: MonadGen m => m a -> m (CommaSep1' a)
 genSizedCommaSep1' ma = Gen.sized $ \n ->
   if n <= 1
-  then CommaSepOne1' <$> ma <*> Gen.maybe genWhitespaces
+  then CommaSepOne1' <$> ma <*> Gen.maybe genComma
   else
     Gen.resize (n-1) $
     Gen.choice
-      [ CommaSepOne1' <$> ma <*> Gen.maybe genWhitespaces
+      [ CommaSepOne1' <$> ma <*> Gen.maybe genComma
       , Gen.sized $ \n -> do
           n' <- Gen.integral (Range.constant 1 (n-1))
           a <- Gen.resize n' ma
           Gen.subtermM
             (Gen.resize (n - n') $ genSizedCommaSep1' ma)
-            (\b -> CommaSepMany1' a <$> genWhitespaces <*> pure b)
+            (\b -> CommaSepMany1' a <$> genComma <*> pure b)
       ]
 
 genAugAssign :: MonadGen m => m (AugAssign ())

--- a/hpython-test/src/Generators/General.hs
+++ b/hpython-test/src/Generators/General.hs
@@ -25,7 +25,7 @@ genTuple :: MonadGen m => m (Expr '[] ()) -> m (Expr '[] ())
 genTuple expr =
   Tuple () <$>
   genTupleItem genWhitespaces expr <*>
-  genWhitespaces <*>
+  genComma <*>
   Gen.maybe (genSizedCommaSep1' $ genTupleItem genWhitespaces expr)
 
 genParam :: MonadGen m => m (Expr '[] ()) -> m (Param '[] ())
@@ -347,7 +347,7 @@ genSmallStatement =
     , sized2M
         (\a b -> (\ws -> Assert () ws a b) <$> genWhitespaces)
         genExpr
-        (sizedMaybe ((,) <$> genWhitespaces <*> genExpr))
+        (sizedMaybe ((,) <$> genComma <*> genExpr))
     ]
 
 genDecorator :: MonadGen m => m (Decorator '[] ())

--- a/src/Language/Python/Internal/Parse.hs
+++ b/src/Language/Python/Internal/Parse.hs
@@ -271,7 +271,7 @@ compFor =
   orTest anySpace
 
 -- | (',' x)* [',']
-commaSepRest :: MonadParsec e PyTokens m => m b -> m ([([Whitespace], b)], Maybe [Whitespace])
+commaSepRest :: MonadParsec e PyTokens m => m b -> m ([(Comma, b)], Maybe Comma)
 commaSepRest x = do
   c <- optional $ snd <$> comma anySpace
   case c of
@@ -981,8 +981,8 @@ suite =
       Left <$> ((,) <$> blank <*> eol) <|>
       Right <$> (statement level =<< i)
 
-comma :: MonadParsec e PyTokens m => m Whitespace -> m (PyToken SrcInfo, [Whitespace])
-comma ws = token ws (\case; TkComma{} -> True; _ -> False) ","
+comma :: MonadParsec e PyTokens m => m Whitespace -> m (PyToken SrcInfo, Comma)
+comma ws = fmap Comma <$> token ws (\case; TkComma{} -> True; _ -> False) ","
 
 colon :: MonadParsec e PyTokens m => m Whitespace -> m (PyToken SrcInfo, [Whitespace])
 colon ws = token ws (\case; TkColon{} -> True; _ -> False) ":"

--- a/src/Language/Python/Internal/Syntax/IR.hs
+++ b/src/Language/Python/Internal/Syntax/IR.hs
@@ -169,7 +169,7 @@ data SmallStatement a
   | Assert a
       [Whitespace]
       (Expr a)
-      (Maybe ([Whitespace], Expr a))
+      (Maybe (Comma, Expr a))
   deriving (Eq, Show, Functor, Foldable, Traversable)
 
 data Param a
@@ -461,7 +461,7 @@ data Expr a
   -- expr
   , _unsafeTupleHead :: Expr a
   -- , spaces
-  , _unsafeTupleWhitespace :: [Whitespace]
+  , _unsafeTupleWhitespace :: Comma
   -- [exprs]
   , _unsafeTupleTail :: Maybe (CommaSep1' (Expr a))
   }

--- a/src/Language/Python/Syntax/Expr.hs
+++ b/src/Language/Python/Syntax/Expr.hs
@@ -611,7 +611,7 @@ data Expr (v :: [*]) a
   -- expr
   , _unsafeTupleHead :: TupleItem v a
   -- , spaces
-  , _unsafeTupleWhitespace :: [Whitespace]
+  , _unsafeTupleWhitespace :: Comma
   -- [exprs]
   , _unsafeTupleTail :: Maybe (CommaSep1' (TupleItem v a))
   }
@@ -724,7 +724,7 @@ instance HasTrailingWhitespace (Expr v a) where
           Bool _ _ ws -> ws
           String _ v -> v ^. trailingWhitespace
           Not _ _ e -> e ^. trailingWhitespace
-          Tuple _ _ ws Nothing -> ws
+          Tuple _ _ (Comma ws) Nothing -> ws
           Tuple _ _ _ (Just cs) -> cs ^. trailingWhitespace
           DictComp _ _ _ ws -> ws
           Dict _ _ _ ws -> ws
@@ -757,9 +757,9 @@ instance HasTrailingWhitespace (Expr v a) where
           Bool a b _ -> Bool a b ws
           String a v -> String a (v & trailingWhitespace .~ ws)
           Not a b c -> Not a b (c & trailingWhitespace .~ ws)
-          Tuple a e _ Nothing -> Tuple a (coerce e) ws Nothing
-          Tuple a b ws (Just cs) ->
-            Tuple a (coerce b) ws (Just $ cs & trailingWhitespace .~ ws)
+          Tuple a e _ Nothing -> Tuple a (coerce e) (Comma ws) Nothing
+          Tuple a b c@(Comma ws) (Just cs) ->
+            Tuple a (coerce b) c (Just $ cs & trailingWhitespace .~ ws)
           DictComp a b c _ -> DictComp a b c ws
           Dict a b c _ -> Dict a b c ws
           SetComp a b c _ -> SetComp a b c ws

--- a/src/Language/Python/Syntax/Statement.hs
+++ b/src/Language/Python/Syntax/Statement.hs
@@ -255,7 +255,7 @@ data SmallStatement (v :: [*]) a
   | Assert a
       [Whitespace]
       (Expr v a)
-      (Maybe ([Whitespace], Expr v a))
+      (Maybe (Comma, Expr v a))
   deriving (Eq, Show, Functor, Foldable, Traversable, Generic)
 
 instance Plated (SmallStatement '[] a) where; plate = gplate

--- a/src/Language/Python/Syntax/Types.hs
+++ b/src/Language/Python/Syntax/Types.hs
@@ -17,7 +17,7 @@ import Control.Lens.TH (makeLenses)
 import Data.List.NonEmpty (NonEmpty)
 
 import Language.Python.Internal.Syntax.Ident (Ident)
-import Language.Python.Syntax.CommaSep (CommaSep, CommaSep1, CommaSep1')
+import Language.Python.Syntax.CommaSep (Comma, CommaSep, CommaSep1, CommaSep1')
 import Language.Python.Syntax.Expr (Arg, Expr, ListItem, Param, TupleItem)
 import Language.Python.Syntax.Statement (Decorator, ExceptAs, Suite, WithItem)
 import Language.Python.Syntax.Whitespace
@@ -195,7 +195,7 @@ data Tuple v a
   = MkTuple
   { _tupleAnn :: a
   , _tupleHead :: TupleItem v a
-  , _tupleComma :: [Whitespace]
+  , _tupleComma :: Comma
   , _tupleTail :: Maybe (CommaSep1' (TupleItem v a))
   } deriving (Eq, Show)
 makeLenses ''Tuple

--- a/src/Language/Python/Validate/Syntax.hs
+++ b/src/Language/Python/Validate/Syntax.hs
@@ -205,6 +205,13 @@ validateWhitespace ann ws =
   then errorVM1 (_UnexpectedComment # ann)
   else pure ws
 
+validateComma
+  :: (AsSyntaxError e v a)
+  => a
+  -> Comma
+  -> ValidateSyntax e Comma
+validateComma a (Comma ws) = Comma <$> validateWhitespace a ws
+
 validateAssignmentSyntax
   :: ( AsSyntaxError e v a
      , Member Indentation v
@@ -512,10 +519,10 @@ validateExprSyntax (BinOp a e1 op e2) =
   validateExprSyntax e1 <*>
   pure op <*>
   validateExprSyntax e2
-validateExprSyntax (Tuple a b ws d) =
+validateExprSyntax (Tuple a b comma d) =
   Tuple a <$>
   validateTupleItemSyntax b <*>
-  validateWhitespace a ws <*>
+  validateComma a comma <*>
   traverseOf (traverse.traverse) validateTupleItemSyntax d
 validateExprSyntax (DictComp a ws1 comp ws2) =
   liftVM1

--- a/test/Syntax.hs
+++ b/test/Syntax.hs
@@ -29,7 +29,7 @@ prop_syntax_1 =
         -- lambda *: None
         Lambda ()
           [Space]
-          (CommaSepMany (StarParam () [] Nothing Nothing) [] CommaSepNone)
+          (CommaSepMany (StarParam () [] Nothing Nothing) (Comma []) CommaSepNone)
           [Space]
           (None () [])
     res <- syntaxValidateExpr e


### PR DESCRIPTION
This type is used in places where previously a [Whitespace] was used with an implicit comma.

I find this much easier. What do you think? Let me know if there are any spots where I've missed commas.

Also what do you think of an IsList instance for `Dot` and `Comma`?