### PR TITLE
Allow megaparsec-7/8 and relax other bounds.

### DIFF
--- a/hpython.cabal
+++ b/hpython.cabal
@@ -124,20 +124,20 @@ library
   build-depends:       base >=4.9 && <5
                      , bifunctors >= 0.1 && < 5.6
                      , bytestring >= 0.10 && < 0.11
-                     , digit >=0.7 && < 0.8
+                     , digit >=0.7 && < 0.10
                      , dlist >=0.8 && <0.9
-                     , lens >= 4 && < 4.18
+                     , lens >= 4 && < 4.20
                      , parsers >= 0.10 && < 0.13
-                     , megaparsec >=6.3 && <7
+                     , megaparsec >= 7 && <8.1
                      , fingertree >=0.1 && <0.2
-                     , generic-lens >=1.0 && <1.2
+                     , generic-lens >=1.0 && <2.1
                      , mtl >= 2.1 && < 2.3
                      , containers >=0.5.7.1 && <0.7
                      , deriving-compat >=0.4 && <0.6
                      , semigroupoids >=5.2.2 && <5.4
                      , text >=1.2 && <1.3
-                     , these >=0.7.4 && <0.9
-                     , validation >= 1 && < 1.1
+                     , these >=0.7.4 && <1.1
+                     , validation >= 1 && < 1.2
                      , parsers-megaparsec >=0.1 && <0.2
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -172,11 +172,11 @@ benchmark bench
   hs-source-dirs:      benchmarks
   build-depends:       base >=4.9 && <5
                      , hpython
-                     , megaparsec >=6.3 && < 7
+                     , megaparsec >= 7 && < 8.1
                      , criterion >= 1 && < 1.6
                      , deepseq
                      , text
-                     , validation >= 1 && < 1.1
+                     , validation >= 1 && < 1.2
   default-language:    Haskell2010
   ghc-options:         -Wall
                        -Wincomplete-patterns
@@ -201,11 +201,11 @@ test-suite hpython-tests
   build-depends:       base >=4.9 && <5
                      , filepath
                      , hpython
-                     , hedgehog >= 0.5 && < 0.7
-                     , lens >= 4 && < 4.18
+                     , hedgehog >= 0.5 && < 1.1
+                     , lens >= 4 && < 4.20
                      , text >=1.2 && <1.3
-                     , megaparsec >=6.3 && < 7
-                     , validation >= 1 && < 1.1
+                     , megaparsec >= 7 && < 8.1
+                     , validation >= 1 && < 1.2
   default-language:    Haskell2010
   ghc-options:         -Wall
                        -Wincomplete-patterns

--- a/src/Language/Python/Internal/Token.hs
+++ b/src/Language/Python/Internal/Token.hs
@@ -230,3 +230,9 @@ pyTokenAnn tk =
     TkShiftRightEq a -> a
     TkDoubleStarEq a -> a
     TkDoubleSlashEq a -> a
+
+-- | Checks if the token represents a line change.
+isNewlineToken :: PyToken a -> Bool
+isNewlineToken (TkNewline _ _) = True
+isNewlineToken (TkContinued _ _) = True
+isNewlineToken _ = False

--- a/src/Language/Python/Parse.hs
+++ b/src/Language/Python/Parse.hs
@@ -43,9 +43,9 @@ import Language.Python.Internal.Lexer
   ( SrcInfo(..), initialSrcInfo, withSrcInfo
   , tokenize, insertTabs
   )
-import Language.Python.Internal.Token (PyToken)
+-- import Language.Python.Internal.Token (PyToken)
 import Language.Python.Internal.Parse
-  ( Parser, runParser, level, module_, statement, exprOrStarList
+  ( Parser, PyTokens, runParser, level, module_, statement, exprOrStarList
   , expr, space
   )
 import Language.Python.Internal.Syntax.IR (AsIRError)
@@ -62,10 +62,10 @@ import qualified Language.Python.Internal.Syntax.IR as IR
 --
 -- https://docs.python.org/3/reference/toplevel_components.html#file-input
 parseModule
-  :: ( AsLexicalError e Char
+  :: ( AsLexicalError e Text
      , AsTabError e SrcInfo
      , AsIncorrectDedent e SrcInfo
-     , AsParseError e (PyToken SrcInfo)
+     , AsParseError e PyTokens
      , AsIRError e SrcInfo
      )
   => FilePath -- ^ File name
@@ -85,10 +85,10 @@ parseModule fp input =
 --
 -- https://docs.python.org/3/reference/compound_stmts.html#grammar-token-statement
 parseStatement
-  :: ( AsLexicalError e Char
+  :: ( AsLexicalError e Text
      , AsTabError e SrcInfo
      , AsIncorrectDedent e SrcInfo
-     , AsParseError e (PyToken SrcInfo)
+     , AsParseError e PyTokens
      , AsIRError e SrcInfo
      )
   => FilePath -- ^ File name
@@ -110,10 +110,10 @@ parseStatement fp input =
 --
 -- https://docs.python.org/3.5/reference/expressions.html#grammar-token-expression_list
 parseExprList
-  :: ( AsLexicalError e Char
+  :: ( AsLexicalError e Text
      , AsTabError e SrcInfo
      , AsIncorrectDedent e SrcInfo
-     , AsParseError e (PyToken SrcInfo)
+     , AsParseError e PyTokens
      , AsIRError e SrcInfo
      )
   => FilePath -- ^ File name
@@ -133,10 +133,10 @@ parseExprList fp input =
 --
 -- https://docs.python.org/3.5/reference/expressions.html#grammar-token-expression
 parseExpr
-  :: ( AsLexicalError e Char
+  :: ( AsLexicalError e Text
      , AsTabError e SrcInfo
      , AsIncorrectDedent e SrcInfo
-     , AsParseError e (PyToken SrcInfo)
+     , AsParseError e PyTokens
      , AsIRError e SrcInfo
      )
   => FilePath -- ^ File name
@@ -156,10 +156,10 @@ parseExpr fp input =
 --
 -- https://docs.python.org/3/reference/toplevel_components.html#file-input
 readModule
-  :: ( AsLexicalError e Char
+  :: ( AsLexicalError e Text
      , AsTabError e SrcInfo
      , AsIncorrectDedent e SrcInfo
-     , AsParseError e (PyToken SrcInfo)
+     , AsParseError e PyTokens
      , AsIRError e SrcInfo
      )
   => FilePath -- ^ File to read
@@ -170,10 +170,10 @@ readModule fp = parseModule fp <$> Text.readFile fp
 --
 -- https://docs.python.org/3/reference/compound_stmts.html#grammar-token-statement
 readStatement
-  :: ( AsLexicalError e Char
+  :: ( AsLexicalError e Text
      , AsTabError e SrcInfo
      , AsIncorrectDedent e SrcInfo
-     , AsParseError e (PyToken SrcInfo)
+     , AsParseError e PyTokens
      , AsIRError e SrcInfo
      )
   => FilePath -- ^ File to read
@@ -184,10 +184,10 @@ readStatement fp = parseStatement fp <$> Text.readFile fp
 --
 -- https://docs.python.org/3.5/reference/expressions.html#grammar-token-expression
 readExpr
-  :: ( AsLexicalError e Char
+  :: ( AsLexicalError e Text
      , AsTabError e SrcInfo
      , AsIncorrectDedent e SrcInfo
-     , AsParseError e (PyToken SrcInfo)
+     , AsParseError e PyTokens
      , AsIRError e SrcInfo
      )
   => FilePath -- ^ File to read
@@ -198,10 +198,10 @@ readExpr fp = parseExpr fp <$> Text.readFile fp
 --
 -- https://docs.python.org/3.5/reference/expressions.html#grammar-token-expression_list
 readExprList
-  :: ( AsLexicalError e Char
+  :: ( AsLexicalError e Text
      , AsTabError e SrcInfo
      , AsIncorrectDedent e SrcInfo
-     , AsParseError e (PyToken SrcInfo)
+     , AsParseError e PyTokens
      , AsIRError e SrcInfo
      )
   => FilePath -- ^ File to read


### PR DESCRIPTION
Makes hpython build with various newer versions of libraries.

The only considerable changes to hpython itself are due to
changes in megaparsec. We now require at least megaparsec-7.
Unfortunately, some minor CPP magic is required to support
megaparsec-8 as well.

The interface of hpython changes slightly as well, because some
of megaparsec's error types are exposed via the interface, and
they have changed in megaparsec-7.